### PR TITLE
feat: Add strict validation for XMLContextFactory - require minimum 2…

### DIFF
--- a/src/main/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactory.kt
+++ b/src/main/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactory.kt
@@ -258,7 +258,10 @@ class XMLContextFactory :
 			val ctx = context ?: throw SAXException("Context not initialized")
 			val inOuts = ctx.getInOuts()
 			if (inOuts.size < 2) {
-				throw SAXException("Railway network must have at least 2 InOut elements (entry and exit points). Found: ${inOuts.size}")
+				throw SAXException(
+					"Railway network must have at least 2 InOut elements (entry and exit points). " +
+						"Found: ${inOuts.size}"
+				)
 			}
 			ended = true
 		}

--- a/src/main/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactory.kt
+++ b/src/main/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactory.kt
@@ -254,8 +254,12 @@ class XMLContextFactory :
 		}
 
 		override fun endDocument() {
-			// Note: InOut validation removed - contexts can be created without InOut elements
-			// for editing purposes. Simulation validation happens when run() is called.
+			// Strict validation: Railway networks must have at least 2 InOut elements (entry/exit points)
+			val ctx = context ?: throw SAXException("Context not initialized")
+			val inOuts = ctx.getInOuts()
+			if (inOuts.size < 2) {
+				throw SAXException("Railway network must have at least 2 InOut elements (entry and exit points). Found: ${inOuts.size}")
+			}
 			ended = true
 		}
 

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/InvalidNetworkTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/InvalidNetworkTest.kt
@@ -13,7 +13,6 @@ import assertk.assertThat
 import assertk.assertions.isFailure
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
-import assertk.assertions.isTrue
 import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
 import cz.vutbr.fit.interlockSim.xml.XMLContextFactory
 import org.junit.jupiter.api.*
@@ -645,7 +644,8 @@ class InvalidNetworkTest : KoinTestBase() {
 			val largeGridXML = """<?xml version="1.0"?>
 				<!DOCTYPE net>
 				<net X="9999" Y="9999">
-					<InOut X="100" Y="100" SpatialType="HORIZONTAL" orientation="false" name="A"/>
+					<InOut X="100" Y="100" SpatialType="HORIZONTAL" orientation="true" name="ENTRY"/>
+					<InOut X="200" Y="100" SpatialType="HORIZONTAL" orientation="false" name="EXIT"/>
 				</net>"""
 			val stream = ByteArrayInputStream(largeGridXML.toByteArray())
 
@@ -661,8 +661,9 @@ class InvalidNetworkTest : KoinTestBase() {
 		fun createContext_minimumGridSize_succeeds() {
 			val minGridXML = """<?xml version="1.0"?>
 				<!DOCTYPE net>
-				<net X="1" Y="1">
-					<InOut X="0" Y="0" SpatialType="HORIZONTAL" orientation="false" name="MINIMAL"/>
+				<net X="10" Y="10">
+					<InOut X="0" Y="0" SpatialType="HORIZONTAL" orientation="true" name="ENTRY"/>
+					<InOut X="1" Y="0" SpatialType="HORIZONTAL" orientation="false" name="EXIT"/>
 				</net>"""
 			val stream = ByteArrayInputStream(minGridXML.toByteArray())
 
@@ -679,6 +680,7 @@ class InvalidNetworkTest : KoinTestBase() {
 			val boundaryXML = """<?xml version="1.0"?>
 				<!DOCTYPE net>
 				<net X="100" Y="100">
+					<InOut X="0" Y="0" SpatialType="HORIZONTAL" orientation="true" name="ENTRY"/>
 					<InOut X="99" Y="99" SpatialType="HORIZONTAL" orientation="false" name="CORNER"/>
 				</net>"""
 			val stream = ByteArrayInputStream(boundaryXML.toByteArray())

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/InvalidNetworkTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/InvalidNetworkTest.kt
@@ -53,30 +53,28 @@ class InvalidNetworkTest : KoinTestBase() {
 	@DisplayName("Missing Required Elements")
 	inner class MissingElementsTests {
 		/**
-		 * Test: Network with no InOut elements can be created (for editing)
-		 * but will fail when trying to run simulation (InOut required for train operations)
-		 * Rationale: InOut (entry/exit points) are required for simulation, not for context creation
+		 * Test: Network with no InOut elements must be rejected (strict validation)
+		 * Rationale: Railway networks require at least 2 InOut elements (entry and exit points)
 		 */
 		@Test
-		fun createContext_noInOutElements_succeeds() {
+		fun createContext_noInOutElements_throwsException() {
 			val networkXML = """<?xml version="1.0"?>
 				<!DOCTYPE net>
 				<net X="100" Y="100">
 				</net>"""
 			val stream = ByteArrayInputStream(networkXML.toByteArray())
 
-			// Context creation should succeed (allows editing empty networks)
-			val context = factory.createContext(stream)
-			assertThat(context).isNotNull()
-			assertThat(context.getInOuts().isEmpty()).isTrue()
+			// Strict validation: must reject networks without sufficient InOut elements
+			assertThatBlock { factory.createContext(stream) }
+				.isFailure()
 		}
 
 		/**
-		 * Test: Network with single InOut but no tracks for connectivity
-		 * Rationale: Single isolated InOut is valid but useless for simulation
+		 * Test: Network with single InOut must be rejected (strict validation)
+		 * Rationale: Railway networks require at least 2 InOut elements (entry and exit points)
 		 */
 		@Test
-		fun createContext_singleInOutNoTracks_succeeds() {
+		fun createContext_singleInOutNoTracks_throwsException() {
 			val networkXML = """<?xml version="1.0"?>
 				<!DOCTYPE net>
 				<net X="100" Y="100">
@@ -84,9 +82,9 @@ class InvalidNetworkTest : KoinTestBase() {
 				</net>"""
 			val stream = ByteArrayInputStream(networkXML.toByteArray())
 
-			// Single InOut is valid - creation should succeed
-			val context = factory.createContext(stream)
-			assertThat(context).isNotNull()
+			// Strict validation: single InOut is insufficient
+			assertThatBlock { factory.createContext(stream) }
+				.isFailure()
 		}
 
 		/**

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
@@ -141,7 +141,7 @@ class ContextInitializationTest : KoinTestBase() {
 		/**
 		 * Validates that loading a valid XML file creates context with expected content.
 		 *
-		 * Test uses minimal-network.xml fixture: simple 2-cell network with one InOut.
+		 * Test uses minimal-network.xml fixture: simple network with two InOut nodes (minimum required).
 		 *
 		 * Railway context: XML files are the persistent format for railway network configs.
 		 */

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopTest.kt
@@ -78,11 +78,11 @@ class ShuntingLoopTest : KoinTestBase() {
 
 		@Test
 		fun constructor_minimimalContext_throwsException() {
-			// Load minimal network fixture (only 1 InOut, insufficient for ShuntingLoop)
+			// Load minimal network fixture (2 InOut nodes but insufficient infrastructure for ShuntingLoop)
 			val xml = xml("/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml")
 			val simContext = createMockSimulationContext(xml)
 
-			// ShuntingLoop expects specific vyhybna.xml structure with 2 InOuts, semaphores, switches
+			// ShuntingLoop expects specific vyhybna.xml structure with 2 InOuts, semaphores, switches, and specific grid coordinates
 			assertThatBlock { ShuntingLoop(simContext, 60L) }
 				.withMessage("ShuntingLoop requires specific network structure from vyhybna.xml")
 				.isFailure()

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/testutil/TestContextBuilder.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/testutil/TestContextBuilder.kt
@@ -219,12 +219,14 @@ class TestContextBuilder {
 	}
 
 	/**
-	 * Creates an empty context with just one InOut for minimal testing.
+	 * Creates a minimal context with two InOut elements (entry and exit).
+	 * Updated to comply with strict validation requiring minimum 2 InOut elements.
 	 *
-	 * @return context with single InOut
+	 * @return context with two InOut elements
 	 */
 	fun buildMinimal(): DefaultContext {
 		return getKoin().get<TestContextBuilder>()
-			.withInOut("A", 1, 1, false)
+			.withInOut("A", 1, 1, true)  // entry point
+			.withInOut("B", 2, 1, false)  // exit point
 			.build()
 	}

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactoryTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactoryTest.kt
@@ -51,12 +51,12 @@ import org.koin.test.inject
  * - Edge cases and malformed input
  *
  * Test Fixtures (src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/):
- * - minimal-network.xml - Single InOut node
+ * - minimal-network.xml - Minimal valid network (2 InOut nodes, no tracks)
  * - linear-track.xml - Two InOut nodes connected by SimpleTrackBlock
  * - switch-basic.xml - RailSwitch with two output tracks
  * - semaphore-basic.xml - RailSemaphore between two InOut nodes
  * - two-tracks-parallel.xml - Two parallel independent tracks
- * - empty-grid.xml - Empty railway network (no cells)
+ * - empty-grid.xml - Grid with minimal elements (2 InOut nodes, no tracks)
  * - invalid-*.xml - Various malformed/invalid XML files
  */
 class XMLContextFactoryTest : KoinTestBase() {
@@ -102,17 +102,19 @@ class XMLContextFactoryTest : KoinTestBase() {
 	@DisplayName("Parsing valid XML fixtures")
 	inner class ValidXMLParsingTests {
 		@Test
-		fun parseXML_minimalNetwork_createsSingleInOut() {
+		fun parseXML_minimalNetwork_createsTwoInOuts() {
 			val xml = getFixtureStream("minimal-network.xml")
 
 			val context = factory.createContext(xml)
 
 			assertThat(context).isNotNull()
 			val grid = context.getRailWayNetGrid()
-			val cell = grid.getCellAt(10, 10)
-			assertThat(cell).isNotNull().isInstanceOf(InOut::class)
-			val inOut = cell as InOut
-			assertThat(inOut.getName()).isEqualTo("A")
+			val cellA = grid.getCellAt(10, 10)
+			val cellB = grid.getCellAt(20, 10)
+			assertThat(cellA).isNotNull().isInstanceOf(InOut::class)
+			assertThat(cellB).isNotNull().isInstanceOf(InOut::class)
+			assertThat((cellA as InOut).getName()).isEqualTo("A")
+			assertThat((cellB as InOut).getName()).isEqualTo("B")
 		}
 
 		@Test
@@ -174,7 +176,7 @@ class XMLContextFactoryTest : KoinTestBase() {
 		}
 
 		@Test
-		fun parseXML_emptyGrid_createsContextWithNoElements() {
+		fun parseXML_emptyGrid_createsContextWithMinimalElements() {
 			val xml = getFixtureStream("empty-grid.xml")
 
 			val context = factory.createContext(xml)
@@ -183,17 +185,20 @@ class XMLContextFactoryTest : KoinTestBase() {
 			val grid = context.getRailWayNetGrid()
 			assertThat(grid.getCols()).isEqualTo(50)
 			assertThat(grid.getRows()).isEqualTo(50)
+			// Should have 2 InOut elements (minimum required)
+			assertThat(context.getInOuts().size).isEqualTo(2)
 		}
 
 		@Test
-		fun parseXML_emptyGrid_hasEmptyGraph() {
+		fun parseXML_emptyGrid_hasNoTracks() {
 			val xml = getFixtureStream("empty-grid.xml")
 
 			val context = factory.createContext(xml)
 
-			assertThat(context.getGraph().nodeSet())
-				.withMessage("Empty grid should have empty graph")
-				.isEmpty()
+			// Grid has InOut nodes but no track connections
+			assertThat(context.getGraph().entrySet().size)
+				.withMessage("Empty grid should have no track connections")
+				.isEqualTo(0)
 		}
 
 		@Test

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactoryTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/xml/XMLContextFactoryTest.kt
@@ -20,6 +20,7 @@ import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import cz.vutbr.fit.interlockSim.context.ContextCreationException
 import cz.vutbr.fit.interlockSim.context.DefaultContext
+import cz.vutbr.fit.interlockSim.objects.cells.Cell
 import cz.vutbr.fit.interlockSim.objects.cells.InOut
 import cz.vutbr.fit.interlockSim.objects.cells.RailSemaphore
 import cz.vutbr.fit.interlockSim.objects.cells.RailSwitch
@@ -479,6 +480,10 @@ class XMLContextFactoryTest : KoinTestBase() {
 			// Create empty context
 			val emptyContext = factory.createEmptyContext()
 
+			// Add minimum required InOut elements to satisfy validation
+			emptyContext.putCell(Point(1, 1), InOut("ENTRY", true, Cell.SpatialType.HORIZONTAL))
+			emptyContext.putCell(Point(2, 1), InOut("EXIT", false, Cell.SpatialType.HORIZONTAL))
+
 			// Save to file
 			factory.saveContext(emptyContext, tempFile!!)
 
@@ -573,6 +578,8 @@ class XMLContextFactoryTest : KoinTestBase() {
 				"<?xml version=\"1.0\"?>\n" +
 					"<!DOCTYPE net>\n" +
 					"<net X=\"500\" Y=\"500\">\n" +
+					"  <InOut X=\"10\" Y=\"10\" SpatialType=\"HORIZONTAL\" orientation=\"true\" name=\"ENTRY\"/>\n" +
+					"  <InOut X=\"490\" Y=\"490\" SpatialType=\"HORIZONTAL\" orientation=\"false\" name=\"EXIT\"/>\n" +
 					"</net>"
 			val stream = ByteArrayInputStream(largeGridXML.toByteArray())
 
@@ -589,7 +596,9 @@ class XMLContextFactoryTest : KoinTestBase() {
 			val minimalGridXML =
 				"<?xml version=\"1.0\"?>\n" +
 					"<!DOCTYPE net>\n" +
-					"<net X=\"1\" Y=\"1\">\n" +
+					"<net X=\"10\" Y=\"10\">\n" +
+					"  <InOut X=\"1\" Y=\"1\" SpatialType=\"HORIZONTAL\" orientation=\"true\" name=\"ENTRY\"/>\n" +
+					"  <InOut X=\"2\" Y=\"1\" SpatialType=\"HORIZONTAL\" orientation=\"false\" name=\"EXIT\"/>\n" +
 					"</net>"
 			val stream = ByteArrayInputStream(minimalGridXML.toByteArray())
 
@@ -597,8 +606,8 @@ class XMLContextFactoryTest : KoinTestBase() {
 
 			assertThat(context).isNotNull()
 			val grid = context.getRailWayNetGrid()
-			assertThat(grid.getCols()).isEqualTo(1)
-			assertThat(grid.getRows()).isEqualTo(1)
+			assertThat(grid.getCols()).isEqualTo(10)
+			assertThat(grid.getRows()).isEqualTo(10)
 		}
 
 		@Test
@@ -607,6 +616,7 @@ class XMLContextFactoryTest : KoinTestBase() {
 				"<?xml version=\"1.0\"?>\n" +
 					"<!DOCTYPE net>\n" +
 					"<net X=\"100\" Y=\"100\">\n" +
+					"  <InOut X=\"1\" Y=\"1\" SpatialType=\"HORIZONTAL\" orientation=\"true\" name=\"ENTRY\"/>\n" +
 					"  <InOut X=\"98\" Y=\"98\" SpatialType=\"HORIZONTAL\" orientation=\"false\" name=\"CORNER\"/>\n" +
 					"</net>"
 			val stream = ByteArrayInputStream(boundaryXML.toByteArray())

--- a/src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/empty-grid.xml
+++ b/src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/empty-grid.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE net>
 <net X="50" Y="50">
+	<InOut X="10" Y="10" SpatialType="HORIZONTAL" orientation="false" name="A"/>
+	<InOut X="20" Y="10" SpatialType="HORIZONTAL" orientation="true" name="B"/>
 </net>

--- a/src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml
+++ b/src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml
@@ -2,4 +2,5 @@
 <!DOCTYPE net>
 <net X="100" Y="100">
 	<InOut X="10" Y="10" SpatialType="HORIZONTAL" orientation="false" name="A"/>
+	<InOut X="20" Y="10" SpatialType="HORIZONTAL" orientation="true" name="B"/>
 </net>


### PR DESCRIPTION
… InOut elements

Implements fail-fast validation strategy for railway network configurations:
- XMLContextFactory now rejects networks with fewer than 2 InOut elements
- Railway networks must have at least one entry and one exit point
- Nested Net elements already rejected (existing validation)

Changes:
- XMLContextFactory.kt: Added InOut count validation in endDocument()
- InvalidNetworkTest.kt: Updated tests to expect failures for invalid networks
- Test fixtures: Updated minimal-network.xml and empty-grid.xml to include 2 InOut elements
- Updated test expectations in XMLContextFactoryTest, ContextInitializationTest, ShuntingLoopTest

Resolves #29