### PR TITLE
Fix CI timeout: Extract Frame tests to AbstractFrameTestBase

### DIFF
--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/MainArgumentParsingTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/MainArgumentParsingTest.kt
@@ -136,25 +136,8 @@ class MainArgumentParsingTest {
 			assertThat(usageNotPrinted).isTrue()
 		}
 
-		@Test
-		fun `edit mode selected with edit argument`() {
-			// Arrange
-			val args = arrayOf("edit")
-
-			// Act & Assert
-			// Edit mode would instantiate Frame, which we can't do without X11
-			// So we verify the mode is recognized by checking usage is NOT printed
-			try {
-				main(args)
-			} catch (e: Exception) {
-				// Frame initialization may fail - that's OK, we're just checking mode selection
-			}
-			val afterErr = getCapturedError()
-
-			// If edit mode was selected, usage should not be printed
-			val usageNotPrinted = !afterErr.contains("usage:")
-			assertThat(usageNotPrinted).isTrue()
-		}
+		// NOTE: edit mode test moved to MainEditModeTest.kt to ensure proper Frame disposal
+		// See GitHub Issue #111 - Frame tests must extend AbstractFrameTestBase
 
 		@Test
 		fun `example mode selected with example argument`() {
@@ -206,24 +189,8 @@ class MainArgumentParsingTest {
 			assertThat(isValidResponse).isTrue()
 		}
 
-		@Test
-		fun `edit mode accepts optional XML file`() {
-			// Arrange
-			val args = arrayOf("edit")
-
-			// Act
-			try {
-				main(args)
-			} catch (e: Exception) {
-				// Frame initialization may fail without X11
-			}
-
-			// Assert
-			// Edit mode should accept zero or more XML file arguments
-			val output = getCapturedError()
-			val isValidMode = !output.contains("usage:") || output.isEmpty()
-			assertThat(isValidMode).isTrue()
-		}
+		// NOTE: edit mode test moved to MainEditModeTest.kt to ensure proper Frame disposal
+		// See GitHub Issue #111 - Frame tests must extend AbstractFrameTestBase
 
 		@Test
 		fun `example mode accepts optional example name`() {
@@ -417,27 +384,8 @@ class MainArgumentParsingTest {
 			assertThat(usageNotShown).isTrue()
 		}
 
-		@Test
-		fun `edit mode attempt without X11 is handled`() {
-			// Arrange
-			val args = arrayOf("edit")
-
-			// Act & Assert
-			try {
-				main(args)
-			} catch (e: Exception) {
-				// Frame initialization will fail without X11 - expected behavior
-				// Just verify the mode was recognized before failure
-				val message = e.message ?: e.javaClass.name
-				val isModeIssue =
-					message.lowercase().contains("frame") ||
-						message.lowercase().contains("awt") ||
-						message.lowercase().contains("x11") ||
-						message.lowercase().contains("display")
-				// If exception occurs, it should be about Frame/GUI, not about mode selection
-				// We don't assert here because X11 failure is expected
-			}
-		}
+		// NOTE: edit mode test moved to MainEditModeTest.kt to ensure proper Frame disposal
+		// See GitHub Issue #111 - Frame tests must extend AbstractFrameTestBase
 
 		@Test
 		fun `example mode with invalid example name`() {

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/AbstractFrameTestBase.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/AbstractFrameTestBase.kt
@@ -1,0 +1,159 @@
+/*
+	Brno University of Technology
+	Faculty of Information Technology
+
+	BSc Thesis       2006/2007
+	Railway Interlocking Simulator
+
+	Abstract base class for tests that create Frame GUI components
+	Provides proper lifecycle management and resource cleanup
+	Phase 4.1 test implementation - 2026
+*/
+
+package cz.vutbr.fit.interlockSim.gui
+
+import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Timeout
+import java.awt.GraphicsEnvironment
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+
+/**
+ * Abstract base class for tests that create Frame GUI components.
+ *
+ * This class provides proper lifecycle management for Frame instances to prevent:
+ * - Resource leaks (undisposed Frame objects)
+ * - CI timeout issues (Frame hanging without disposal)
+ * - Thread safety issues (GUI operations on non-EDT threads)
+ *
+ * All tests that extend this class:
+ * - Are tagged as @Tag("integration-test") and run separately
+ * - Have proper Frame disposal in @AfterEach
+ * - Run GUI operations on EDT via SwingUtilities.invokeAndWait
+ * - Skip execution in headless environments
+ * - Have timeout annotations to prevent indefinite hangs
+ *
+ * Subclasses should:
+ * - Call super.setUp() in their @BeforeEach if they override it
+ * - Call super.tearDown() in their @AfterEach if they override it
+ * - Store Frame references for proper disposal
+ * - Use SwingUtilities.invokeAndWait for all GUI operations
+ *
+ * Example usage:
+ * ```
+ * class MyFrameTest : AbstractFrameTestBase() {
+ *     private lateinit var frame: Frame
+ *
+ *     @BeforeEach
+ *     override fun setUp() {
+ *         super.setUp()
+ *         SwingUtilities.invokeAndWait {
+ *             frame = Frame()
+ *         }
+ *     }
+ *
+ *     @Test
+ *     @Timeout(value = 5, unit = TimeUnit.SECONDS)
+ *     fun testFrameBehavior() {
+ *         // Test code here
+ *     }
+ * }
+ * ```
+ *
+ * Architecture notes:
+ * - Extends KoinTestBase for dependency injection support
+ * - Tagged as integration test at class level
+ * - Checks for headless environment and skips tests if X11 unavailable
+ * - Provides centralized Frame disposal logic
+ *
+ * GitHub Issue: #111 (CI timeout prevention)
+ */
+@Tag("integration-test")
+abstract class AbstractFrameTestBase : KoinTestBase() {
+	/**
+	 * List of Frame instances created during test execution.
+	 * Subclasses should add Frame references to this list for automatic disposal.
+	 */
+	protected val frames: MutableList<Frame> = mutableListOf()
+
+	/**
+	 * Setup method that checks for headless environment.
+	 * Subclasses should call super.setUp() if they override this.
+	 */
+	@BeforeEach
+	open fun setUp() {
+		// Check if we're in a headless environment (no X11 display)
+		val isHeadless = GraphicsEnvironment.isHeadless()
+		Assumptions.assumeFalse(
+			isHeadless,
+			"Skipping GUI test - headless environment (no X11 display)"
+		)
+	}
+
+	/**
+	 * Teardown method that disposes all Frame instances.
+	 * Subclasses should call super.tearDown() if they override this.
+	 */
+	@AfterEach
+	open fun tearDown() {
+		// Dispose all frames on EDT to prevent resource leaks
+		frames.forEach { frame ->
+			try {
+				SwingUtilities.invokeAndWait {
+					if (frame.isDisplayable) {
+						frame.dispose()
+					}
+				}
+			} catch (e: Exception) {
+				// Log but don't fail test cleanup
+				System.err.println("Warning: Failed to dispose Frame: ${e.message}")
+			}
+		}
+		frames.clear()
+	}
+
+	/**
+	 * Helper method to create a Frame on EDT and register it for disposal.
+	 * @return The created Frame instance
+	 */
+	protected fun createFrame(): Frame {
+		var frame: Frame? = null
+		SwingUtilities.invokeAndWait {
+			frame = Frame()
+		}
+		frames.add(frame!!)
+		return frame!!
+	}
+
+	/**
+	 * Helper method to safely show a Frame on EDT.
+	 * @param frame The Frame to show
+	 */
+	protected fun showFrame(frame: Frame) {
+		SwingUtilities.invokeAndWait {
+			frame.isVisible = true
+		}
+	}
+
+	/**
+	 * Helper method to safely hide a Frame on EDT.
+	 * @param frame The Frame to hide
+	 */
+	protected fun hideFrame(frame: Frame) {
+		SwingUtilities.invokeAndWait {
+			frame.isVisible = false
+		}
+	}
+
+	/**
+	 * Helper method to run code on EDT and wait for completion.
+	 * @param block The code to run on EDT
+	 */
+	protected fun runOnEDT(block: () -> Unit) {
+		SwingUtilities.invokeAndWait(block)
+	}
+}

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/AbstractFrameTestBase.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/AbstractFrameTestBase.kt
@@ -17,9 +17,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Timeout
 import java.awt.GraphicsEnvironment
-import java.util.concurrent.TimeUnit
 import javax.swing.SwingUtilities
 
 /**
@@ -125,8 +123,9 @@ abstract class AbstractFrameTestBase : KoinTestBase() {
 		SwingUtilities.invokeAndWait {
 			frame = Frame()
 		}
-		frames.add(frame!!)
-		return frame!!
+		val createdFrame = frame ?: error("Frame creation failed")
+		frames.add(createdFrame)
+		return createdFrame
 	}
 
 	/**

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+import java.awt.AWTError
+import java.awt.HeadlessException
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.concurrent.TimeUnit
@@ -34,6 +37,8 @@ import java.util.concurrent.TimeUnit
  *
  * Key differences from original MainArgumentParsingTest:
  * - Extends AbstractFrameTestBase for proper Frame disposal
+ * - Does NOT extend KoinTestBase to avoid double Koin initialization
+ * - main() starts Koin with interlockSimModule, not testModule
  * - Tagged as @Tag("integration-test") via base class
  * - Has timeout annotations to prevent 10-minute hangs
  * - Properly disposes Frame instances created by main()
@@ -41,9 +46,11 @@ import java.util.concurrent.TimeUnit
  *
  * Architecture notes:
  * - main(arrayOf("edit")) creates Frame via lazy initialization
+ * - main() calls startKoin() with interlockSimModule
  * - Frame is registered in Koin DI container
  * - We retrieve Frame from Koin after main() call for disposal
  * - tearDown() in base class handles Frame disposal automatically
+ * - Koin is stopped after each test to clean up resources
  *
  * GitHub Issue: #111 (CI timeout prevention)
  */
@@ -58,8 +65,10 @@ class MainEditModeTest : AbstractFrameTestBase() {
 
 	@BeforeEach
 	override fun setUp() {
+		// Check for headless environment first (may skip test via Assumptions.assumeFalse)
 		super.setUp()
 
+		// Only set up System.err capture if we passed the headless check
 		// Capture System.err to verify error messages
 		systemErr = System.err
 		val errStream = ByteArrayOutputStream()
@@ -87,14 +96,36 @@ class MainEditModeTest : AbstractFrameTestBase() {
 			// Frame might not have been created, that's okay
 		}
 
-		// Call base class tearDown to dispose all frames
-		// Note: KoinTestBase.tearDownKoin() will call stopKoin() after this method
+		// Call base class tearDown to dispose all frames collected in this test
 		super.tearDown()
+
+		// Stop Koin to clean up the DI container started by main()
+		// Note: main() calls startKoin(), so we must clean it up here
+		try {
+			if (GlobalContext.getOrNull() != null) {
+				stopKoin()
+			}
+		} catch (e: Exception) {
+			// Koin might already be stopped, that's okay
+		}
 	}
 
 	private fun getCapturedError(): String {
 		System.err.flush()
 		return capturedErr?.toString() ?: ""
+	}
+
+	/**
+	 * Checks if an exception is GUI-related (Frame, AWT, X11, display, headless).
+	 * Used to verify that exceptions are due to GUI initialization failures, not mode selection errors.
+	 */
+	private fun isGuiRelatedException(e: Exception): Boolean {
+		val message = e.message ?: e.javaClass.name
+		return message.lowercase().contains("frame") ||
+			message.lowercase().contains("awt") ||
+			message.lowercase().contains("x11") ||
+			message.lowercase().contains("display") ||
+			message.lowercase().contains("headless")
 	}
 
 	@Test
@@ -109,14 +140,24 @@ class MainEditModeTest : AbstractFrameTestBase() {
 		// So we verify the mode is recognized by checking usage is NOT printed
 		try {
 			main(args)
+			// Success - Frame was created (non-headless environment)
+			val afterErr = getCapturedError()
+			val usageNotPrinted = !afterErr.contains("usage:")
+			assertThat(usageNotPrinted).isTrue()
+		} catch (e: HeadlessException) {
+			// Expected in headless environment - mode was recognized but GUI creation failed
+			val afterErr = getCapturedError()
+			val usageNotPrinted = !afterErr.contains("usage:")
+			assertThat(usageNotPrinted).isTrue()
+		} catch (e: AWTError) {
+			// Expected in headless environment - mode was recognized but GUI creation failed
+			val afterErr = getCapturedError()
+			val usageNotPrinted = !afterErr.contains("usage:")
+			assertThat(usageNotPrinted).isTrue()
 		} catch (e: Exception) {
-			// Frame initialization may fail - that's OK, we're just checking mode selection
+			// Check if it's a GUI-related exception (mode was recognized)
+			assertThat(isGuiRelatedException(e)).isTrue()
 		}
-		val afterErr = getCapturedError()
-
-		// If edit mode was selected, usage should not be printed
-		val usageNotPrinted = !afterErr.contains("usage:")
-		assertThat(usageNotPrinted).isTrue()
 	}
 
 	@Test
@@ -129,16 +170,20 @@ class MainEditModeTest : AbstractFrameTestBase() {
 		// Act & Assert
 		// Edit mode should accept zero or more XML file arguments
 		// In headless environment, Frame creation will fail, but mode should be recognized
-		val output = try {
+		try {
 			main(args)
-			getCapturedError()
+			// Success - Frame was created (non-headless environment)
+			val output = getCapturedError()
+			val isValidMode = !output.contains("usage:") || output.isEmpty()
+			assertThat(isValidMode).isTrue()
+		} catch (e: HeadlessException) {
+			// Expected in headless environment - mode was recognized but GUI creation failed
+		} catch (e: AWTError) {
+			// Expected in headless environment - mode was recognized but GUI creation failed
 		} catch (e: Exception) {
-			// Frame initialization may fail without X11, check if mode was recognized first
-			getCapturedError()
+			// Check if it's a GUI-related exception (mode was recognized)
+			assertThat(isGuiRelatedException(e)).isTrue()
 		}
-		
-		val isValidMode = !output.contains("usage:") || output.isEmpty()
-		assertThat(isValidMode).isTrue()
 	}
 
 	@Test
@@ -150,24 +195,19 @@ class MainEditModeTest : AbstractFrameTestBase() {
 
 		// Act & Assert
 		// In headless environment, Frame creation will fail but mode should be recognized
-		val exception = try {
+		try {
 			main(args)
-			null  // Success - Frame was created (non-headless environment)
+			// Success - Frame was created (non-headless environment)
+			// Test passes - edit mode was recognized and handled
+		} catch (e: HeadlessException) {
+			// Expected in headless environment - verify mode was recognized (GUI exception, not mode error)
+			// Test passes - exception is GUI-related as expected
+		} catch (e: AWTError) {
+			// Expected in headless environment - verify mode was recognized (GUI exception, not mode error)
+			// Test passes - exception is GUI-related as expected
 		} catch (e: Exception) {
-			e  // Capture exception for verification
+			// Verify that exception is GUI-related (mode was recognized), not mode-selection-related
+			assertThat(isGuiRelatedException(e)).isTrue()
 		}
-
-		// Verify that if an exception occurred, it's GUI-related, not mode-selection-related
-		if (exception != null) {
-			val message = exception.message ?: exception.javaClass.name
-			val isGuiRelated =
-				message.lowercase().contains("frame") ||
-					message.lowercase().contains("awt") ||
-					message.lowercase().contains("x11") ||
-					message.lowercase().contains("display") ||
-					message.lowercase().contains("headless")
-			assertThat(isGuiRelated).isTrue()
-		}
-		// If no exception, edit mode was successfully initialized (non-headless environment)
 	}
 }

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
@@ -1,0 +1,164 @@
+/*
+	Brno University of Technology
+	Faculty of Information Technology
+
+	BSc Thesis       2006/2007
+	Railway Interlocking Simulator
+
+	Unit tests for Main class edit mode Frame handling
+	Extracted from MainArgumentParsingTest to ensure proper Frame disposal
+	Phase 4.1 test implementation - 2026
+*/
+
+package cz.vutbr.fit.interlockSim.gui
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isTrue
+import cz.vutbr.fit.interlockSim.main
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for Main class edit mode that creates Frame GUI components.
+ *
+ * These tests were extracted from MainArgumentParsingTest to ensure proper
+ * Frame lifecycle management and prevent CI timeouts.
+ *
+ * Key differences from original MainArgumentParsingTest:
+ * - Extends AbstractFrameTestBase for proper Frame disposal
+ * - Tagged as @Tag("integration-test") via base class
+ * - Has timeout annotations to prevent 10-minute hangs
+ * - Properly disposes Frame instances created by main()
+ * - Runs on separate integration test task
+ *
+ * Architecture notes:
+ * - main(arrayOf("edit")) creates Frame via lazy initialization
+ * - Frame is registered in Koin DI container
+ * - We retrieve Frame from Koin after main() call for disposal
+ * - tearDown() in base class handles Frame disposal automatically
+ *
+ * GitHub Issue: #111 (CI timeout prevention)
+ */
+@DisplayName("Main Edit Mode with Frame")
+class MainEditModeTest : AbstractFrameTestBase() {
+	private lateinit var systemErr: PrintStream
+	private lateinit var capturedErr: ByteArrayOutputStream
+
+	@BeforeEach
+	override fun setUp() {
+		super.setUp()
+
+		// Capture System.err to verify error messages
+		systemErr = System.err
+		capturedErr = ByteArrayOutputStream()
+		System.setErr(PrintStream(capturedErr))
+	}
+
+	@AfterEach
+	override fun tearDown() {
+		// Restore original System.err
+		System.setErr(systemErr)
+
+		// Get Frame from Koin if it was created and add to disposal list
+		try {
+			val koin = GlobalContext.getOrNull()
+			if (koin != null) {
+				val frame = koin.get<Frame>()
+				frames.add(frame)
+			}
+		} catch (e: Exception) {
+			// Frame might not have been created, that's okay
+		}
+
+		// Clean up Koin context if it was started by main()
+		try {
+			stopKoin()
+		} catch (e: Exception) {
+			// Koin might not be started, that's okay
+		}
+
+		// Call base class tearDown to dispose all frames
+		super.tearDown()
+	}
+
+	private fun getCapturedError(): String {
+		System.err.flush()
+		return capturedErr.toString()
+	}
+
+	@Test
+	@Timeout(value = 10, unit = TimeUnit.SECONDS)
+	@DisplayName("edit mode selected with edit argument")
+	fun editModeSelectedWithEditArgument() {
+		// Arrange
+		val args = arrayOf("edit")
+
+		// Act & Assert
+		// Edit mode would instantiate Frame, which we can't do without X11
+		// So we verify the mode is recognized by checking usage is NOT printed
+		try {
+			main(args)
+		} catch (e: Exception) {
+			// Frame initialization may fail - that's OK, we're just checking mode selection
+		}
+		val afterErr = getCapturedError()
+
+		// If edit mode was selected, usage should not be printed
+		val usageNotPrinted = !afterErr.contains("usage:")
+		assertThat(usageNotPrinted).isTrue()
+	}
+
+	@Test
+	@Timeout(value = 10, unit = TimeUnit.SECONDS)
+	@DisplayName("edit mode accepts optional XML file")
+	fun editModeAcceptsOptionalXmlFile() {
+		// Arrange
+		val args = arrayOf("edit")
+
+		// Act
+		try {
+			main(args)
+		} catch (e: Exception) {
+			// Frame initialization may fail without X11
+		}
+
+		// Assert
+		// Edit mode should accept zero or more XML file arguments
+		val output = getCapturedError()
+		val isValidMode = !output.contains("usage:") || output.isEmpty()
+		assertThat(isValidMode).isTrue()
+	}
+
+	@Test
+	@Timeout(value = 10, unit = TimeUnit.SECONDS)
+	@DisplayName("edit mode attempt without X11 is handled")
+	fun editModeAttemptWithoutX11IsHandled() {
+		// Arrange
+		val args = arrayOf("edit")
+
+		// Act & Assert
+		try {
+			main(args)
+		} catch (e: Exception) {
+			// Frame initialization will fail without X11 - expected behavior
+			// Just verify the mode was recognized before failure
+			val message = e.message ?: e.javaClass.name
+			val isModeIssue =
+				message.lowercase().contains("frame") ||
+					message.lowercase().contains("awt") ||
+					message.lowercase().contains("x11") ||
+					message.lowercase().contains("display")
+			// If exception occurs, it should be about Frame/GUI, not about mode selection
+			// We don't assert here because X11 failure is expected
+		}
+	}
+}

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
@@ -16,6 +16,7 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isTrue
 import cz.vutbr.fit.interlockSim.main
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -28,6 +29,8 @@ import java.awt.HeadlessException
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Tests for Main class edit mode that creates Frame GUI components.
@@ -94,6 +97,7 @@ class MainEditModeTest : AbstractFrameTestBase() {
 			}
 		} catch (e: Exception) {
 			// Frame might not have been created, that's okay
+			logger.debug(e) { "Failed to retrieve Frame from Koin during tearDown" }
 		}
 
 		// Call base class tearDown to dispose all frames collected in this test

--- a/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
+++ b/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/MainEditModeTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.koin.core.context.GlobalContext
-import org.koin.core.context.stopKoin
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.util.concurrent.TimeUnit
@@ -50,8 +49,12 @@ import java.util.concurrent.TimeUnit
  */
 @DisplayName("Main Edit Mode with Frame")
 class MainEditModeTest : AbstractFrameTestBase() {
-	private lateinit var systemErr: PrintStream
-	private lateinit var capturedErr: ByteArrayOutputStream
+	// Nullable properties to handle JUnit lifecycle:
+	// - JUnit calls tearDown() even when tests are skipped via Assumptions.assumeFalse()
+	// - If setUp() is skipped (headless environment), these remain null
+	// - tearDown() must handle null case gracefully
+	private var systemErr: PrintStream? = null
+	private var capturedErr: ByteArrayOutputStream? = null
 
 	@BeforeEach
 	override fun setUp() {
@@ -59,40 +62,39 @@ class MainEditModeTest : AbstractFrameTestBase() {
 
 		// Capture System.err to verify error messages
 		systemErr = System.err
-		capturedErr = ByteArrayOutputStream()
-		System.setErr(PrintStream(capturedErr))
+		val errStream = ByteArrayOutputStream()
+		capturedErr = errStream
+		System.setErr(PrintStream(errStream))
 	}
 
 	@AfterEach
 	override fun tearDown() {
-		// Restore original System.err
-		System.setErr(systemErr)
+		// Restore original System.err (only if setUp completed)
+		systemErr?.let { System.setErr(it) }
 
 		// Get Frame from Koin if it was created and add to disposal list
+		// Important: Frame is a singleton, so koin.getOrNull() only retrieves it if already instantiated
 		try {
 			val koin = GlobalContext.getOrNull()
 			if (koin != null) {
-				val frame = koin.get<Frame>()
-				frames.add(frame)
+				// Use getOrNull to avoid creating Frame if it wasn't instantiated yet
+				val frame = koin.getOrNull<Frame>()
+				if (frame != null) {
+					frames.add(frame)
+				}
 			}
 		} catch (e: Exception) {
 			// Frame might not have been created, that's okay
 		}
 
-		// Clean up Koin context if it was started by main()
-		try {
-			stopKoin()
-		} catch (e: Exception) {
-			// Koin might not be started, that's okay
-		}
-
 		// Call base class tearDown to dispose all frames
+		// Note: KoinTestBase.tearDownKoin() will call stopKoin() after this method
 		super.tearDown()
 	}
 
 	private fun getCapturedError(): String {
 		System.err.flush()
-		return capturedErr.toString()
+		return capturedErr?.toString() ?: ""
 	}
 
 	@Test
@@ -124,16 +126,17 @@ class MainEditModeTest : AbstractFrameTestBase() {
 		// Arrange
 		val args = arrayOf("edit")
 
-		// Act
-		try {
-			main(args)
-		} catch (e: Exception) {
-			// Frame initialization may fail without X11
-		}
-
-		// Assert
+		// Act & Assert
 		// Edit mode should accept zero or more XML file arguments
-		val output = getCapturedError()
+		// In headless environment, Frame creation will fail, but mode should be recognized
+		val output = try {
+			main(args)
+			getCapturedError()
+		} catch (e: Exception) {
+			// Frame initialization may fail without X11, check if mode was recognized first
+			getCapturedError()
+		}
+		
 		val isValidMode = !output.contains("usage:") || output.isEmpty()
 		assertThat(isValidMode).isTrue()
 	}
@@ -146,19 +149,25 @@ class MainEditModeTest : AbstractFrameTestBase() {
 		val args = arrayOf("edit")
 
 		// Act & Assert
-		try {
+		// In headless environment, Frame creation will fail but mode should be recognized
+		val exception = try {
 			main(args)
+			null  // Success - Frame was created (non-headless environment)
 		} catch (e: Exception) {
-			// Frame initialization will fail without X11 - expected behavior
-			// Just verify the mode was recognized before failure
-			val message = e.message ?: e.javaClass.name
-			val isModeIssue =
+			e  // Capture exception for verification
+		}
+
+		// Verify that if an exception occurred, it's GUI-related, not mode-selection-related
+		if (exception != null) {
+			val message = exception.message ?: exception.javaClass.name
+			val isGuiRelated =
 				message.lowercase().contains("frame") ||
 					message.lowercase().contains("awt") ||
 					message.lowercase().contains("x11") ||
-					message.lowercase().contains("display")
-			// If exception occurs, it should be about Frame/GUI, not about mode selection
-			// We don't assert here because X11 failure is expected
+					message.lowercase().contains("display") ||
+					message.lowercase().contains("headless")
+			assertThat(isGuiRelated).isTrue()
 		}
+		// If no exception, edit mode was successfully initialized (non-headless environment)
 	}
 }


### PR DESCRIPTION
## Summary

Creates AbstractFrameTestBase as a base class for tests that open Frame GUI components, fixing the CI timeout issue where Frame instances were never disposed.

## Changes

- ✅ Created `AbstractFrameTestBase.kt` with Frame lifecycle management
- ✅ Created `MainEditModeTest.kt` extending AbstractFrameTestBase
- ✅ Extracted 3 edit-mode tests from `MainArgumentParsingTest.kt`
- ✅ Tagged as `@Tag("integration-test")` to run separately
- ✅ Added 10-second timeouts to prevent indefinite hangs
- ✅ Proper Frame disposal via Koin DI access
- ✅ Headless environment detection

## Fixes

Closes #111

The CI timeout was caused by tests calling `main(arrayOf("edit"))` which created Frame instances that were never disposed, causing the build to hang for 10 minutes.

## Test Plan

- [ ] Run `./gradlew test` to verify unit tests pass (excludes Frame tests)
- [ ] Run `./gradlew integrationTest` to verify Frame tests pass
- [ ] Verify tests complete within timeout limits
- [ ] Confirm no resource leaks or hanging processes

Generated with [Claude Code](https://claude.ai/code)