### PR TITLE
fix: add kDisco 0.2.0 build step to Dockerfile (mirrors CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Git worktrees
+.worktrees/
+
 # Build directories
 build/
 jar/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ COPY .editorconfig /build/interlockSim/
 # built from source and published to mavenLocal before interlockSim compiles.
 # Building kDisco also downloads jDisco (its transitive dep) into the
 # Gradle cache, making it available for interlockSim's dependency resolution.
+# Requires outbound HTTPS to github.com on cache miss. In air-gapped environments,
+# pre-populate the BuildKit cache by running a connected build first.
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,36 @@ COPY detekt.yml /build/interlockSim/
 COPY detekt-strict.yml /build/interlockSim/
 COPY .editorconfig /build/interlockSim/
 
+# Install git (required for cloning kDisco in Layer 2.5)
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Layer 2.5: Build kDisco 0.2.0 from source if not in cache
+# Mirrors the CI workflow (gradle-java21.yml / sonarqube.yml).
+# kDisco 0.2.0 is not published to any public Maven repo, so it must be
+# built from source and published to mavenLocal before interlockSim compiles.
+# Building kDisco also downloads jDisco (its transitive dep) into the
+# Gradle cache, making it available for interlockSim's dependency resolution.
+RUN --mount=type=cache,target=/root/.gradle/caches \
+    --mount=type=cache,target=/root/.gradle/wrapper \
+    --mount=type=cache,target=/root/.m2/repository \
+    KDISCO_JAR="/root/.m2/repository/cz/hovorka/kdisco/kdisco-core-api-jvm/0.2.0/kdisco-core-api-jvm-0.2.0.jar"; \
+    if [ ! -f "$KDISCO_JAR" ]; then \
+        echo "kDisco 0.2.0 not cached — building from source..."; \
+        KDISCO_COMMIT="7cb97d0cd5747972775a4719f525a19928faa92b"; \
+        git clone https://github.com/bedaHovorka/kdisco.git /tmp/kdisco; \
+        cd /tmp/kdisco; \
+        git checkout "$KDISCO_COMMIT"; \
+        sed -i 's/version[[:space:]]*=[[:space:]]*"0\.2\.0-SNAPSHOT"/version = "0.2.0"/' build.gradle.kts; \
+        grep -E 'version[[:space:]]*=[[:space:]]*"0\.2\.0"' build.gradle.kts; \
+        GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
+        ./gradlew :kdisco-core-api:publishToMavenLocal --no-daemon; \
+    else \
+        echo "kDisco 0.2.0 found in cache — skipping build"; \
+    fi
+
 # Layer 3: Resolve dependencies with BuildKit cache mount
 # Gradle caches: dependencies, build cache, and Gradle distributions
-# mavenLocal cache is also mounted for jDisco fallback
+# kDisco 0.2.0 and jDisco are now available via mavenLocal / Gradle cache
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ ARG GITHUB_TOKEN
 
 WORKDIR /build/interlockSim
 
+# Install git before COPY layers so this layer is cached independently of source changes.
+# Moving it here avoids re-downloading git on every gradle.properties / build.gradle.kts bump.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 # Layer 1: Copy Gradle wrapper files (cached until wrapper version changes)
 # These files are checked into git and ensure consistent Gradle version
 COPY gradlew /build/interlockSim/
@@ -43,9 +47,6 @@ COPY build.gradle.kts /build/interlockSim/
 COPY detekt.yml /build/interlockSim/
 COPY detekt-strict.yml /build/interlockSim/
 COPY .editorconfig /build/interlockSim/
-
-# Install git (required for cloning kDisco in Layer 2.5)
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 
 # Layer 2.5: Build kDisco 0.2.0 from source if not in cache
 # Mirrors the CI workflow (gradle-java21.yml / sonarqube.yml).
@@ -67,6 +68,7 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
         grep -E 'version[[:space:]]*=[[:space:]]*"0\.2\.0"' build.gradle.kts; \
         GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
         ./gradlew :kdisco-core-api:publishToMavenLocal --no-daemon; \
+        rm -rf /tmp/kdisco; \
     else \
         echo "kDisco 0.2.0 found in cache — skipping build"; \
     fi


### PR DESCRIPTION
## Summary

- PR #381 pinned kDisco from `0.2.0-SNAPSHOT` to `0.2.0` and added a cache-gated build step to both CI workflows (`gradle-java21.yml`, `sonarqube.yml`), but the **Dockerfile was not updated**.
- As a result `docker compose build` fails on a fresh cache: kDisco 0.2.0 is not in any public Maven repo, and jDisco (kDisco's transitive dependency) is unreachable without building kDisco first.
- Fix: add the same cache-gated kDisco build step to the Dockerfile (pins to commit `7cb97d0c`, patches version to `0.2.0`, publishes to mavenLocal).

## Test plan

- [ ] `docker compose build app` succeeds on a fresh Docker cache (no `~/.m2/cz/hovorka/kdisco/`)
- [ ] `docker compose build app` is fast on subsequent builds (cache hit skips kDisco build)
- [ ] `./gradlew build` still passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)