### PR TITLE
fix: copy jDisco to mavenLocal after kDisco build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,11 @@ COPY .editorconfig /build/interlockSim/
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \
+    JDISCO_VERSION="1.2.0"; \
     KDISCO_JAR="/root/.m2/repository/cz/hovorka/kdisco/kdisco-core-api-jvm/0.2.0/kdisco-core-api-jvm-0.2.0.jar"; \
-    JDISCO_JAR="/root/.m2/repository/dk/ruc/keld/jdisco/1.2.0/jdisco-1.2.0.jar"; \
+    JDISCO_JAR="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.jar"; \
     if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR" ]; then \
-        echo "kDisco 0.2.0 or jDisco 1.2.0 not cached — building from source..."; \
+        echo "kDisco 0.2.0 or jDisco ${JDISCO_VERSION} not cached — building from source..."; \
         KDISCO_COMMIT="7cb97d0cd5747972775a4719f525a19928faa92b"; \
         git clone https://github.com/bedaHovorka/kdisco.git /tmp/kdisco; \
         cd /tmp/kdisco; \
@@ -73,14 +74,16 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
         GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
         ./gradlew :kdisco-core-api:publishToMavenLocal --no-daemon; \
         rm -rf /tmp/kdisco; \
-        JDISCO_DIR="/root/.m2/repository/dk/ruc/keld/jdisco/1.2.0"; \
+        JDISCO_DIR="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}"; \
         mkdir -p "$JDISCO_DIR"; \
-        JDISCO_CACHE=$(find /root/.gradle/caches/modules-2 -name "jdisco-1.2.0.jar" 2>/dev/null | head -1); \
-        JDISCO_POM=$(find /root/.gradle/caches/modules-2 -name "jdisco-1.2.0.pom" 2>/dev/null | head -1); \
-        [ -n "$JDISCO_CACHE" ] && cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-1.2.0.jar" && echo "jDisco 1.2.0 installed to mavenLocal"; \
-        [ -n "$JDISCO_POM" ]   && cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-1.2.0.pom"; \
+        JDISCO_CACHE=$(find /root/.gradle/caches/modules-2 -name "jdisco-${JDISCO_VERSION}.jar" 2>/dev/null | head -1); \
+        JDISCO_POM=$(find /root/.gradle/caches/modules-2 -name "jdisco-${JDISCO_VERSION}.pom" 2>/dev/null | head -1); \
+        [ -n "$JDISCO_CACHE" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.jar not found in Gradle cache"; exit 1; }; \
+        [ -n "$JDISCO_POM" ]   || { echo "ERROR: jdisco-${JDISCO_VERSION}.pom not found in Gradle cache"; exit 1; }; \
+        cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" && echo "jDisco ${JDISCO_VERSION} JAR installed to mavenLocal"; \
+        cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" && echo "jDisco ${JDISCO_VERSION} POM installed to mavenLocal"; \
     else \
-        echo "kDisco 0.2.0 and jDisco 1.2.0 found in cache — skipping build"; \
+        echo "kDisco 0.2.0 and jDisco ${JDISCO_VERSION} found in cache — skipping build"; \
     fi
 
 # Layer 3: Resolve dependencies with BuildKit cache mount

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,14 +57,15 @@ COPY .editorconfig /build/interlockSim/
 # it as a transitive dep of kDisco without GitHub Packages authentication.
 # Requires outbound HTTPS to github.com on cache miss. In air-gapped environments,
 # pre-populate the BuildKit cache by running a connected build first.
+# JDISCO_VERSION below must be kept in sync with the jdisco version in build.gradle.kts.
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \
     JDISCO_VERSION="1.2.0"; \
     KDISCO_JAR="/root/.m2/repository/cz/hovorka/kdisco/kdisco-core-api-jvm/0.2.0/kdisco-core-api-jvm-0.2.0.jar"; \
-    JDISCO_JAR="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.jar"; \
+    JDISCO_JAR_M2="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.jar"; \
     JDISCO_POM_M2="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.pom"; \
-    if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR" ] || [ ! -f "$JDISCO_POM_M2" ]; then \
+    if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR_M2" ] || [ ! -f "$JDISCO_POM_M2" ]; then \
         echo "kDisco 0.2.0 or jDisco ${JDISCO_VERSION} not cached — building from source..."; \
         KDISCO_COMMIT="7cb97d0cd5747972775a4719f525a19928faa92b"; \
         git clone https://github.com/bedaHovorka/kdisco.git /tmp/kdisco; \
@@ -83,8 +84,6 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
         [ -n "$JDISCO_POM" ]   || { echo "ERROR: jdisco-${JDISCO_VERSION}.pom not found in Gradle cache"; exit 1; }; \
         cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" || { echo "ERROR: failed to copy jdisco-${JDISCO_VERSION}.jar into mavenLocal at $JDISCO_DIR"; exit 1; }; \
         cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" || { echo "ERROR: failed to copy jdisco-${JDISCO_VERSION}.pom into mavenLocal at $JDISCO_DIR"; exit 1; }; \
-        [ -f "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.jar not present in mavenLocal at $JDISCO_DIR after copy"; exit 1; }; \
-        [ -f "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.pom not present in mavenLocal at $JDISCO_DIR after copy"; exit 1; }; \
         echo "jDisco ${JDISCO_VERSION} JAR and POM installed to mavenLocal at $JDISCO_DIR"; \
     else \
         echo "kDisco 0.2.0 and jDisco ${JDISCO_VERSION} found in cache — skipping build"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
     JDISCO_VERSION="1.2.0"; \
     KDISCO_JAR="/root/.m2/repository/cz/hovorka/kdisco/kdisco-core-api-jvm/0.2.0/kdisco-core-api-jvm-0.2.0.jar"; \
     JDISCO_JAR="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.jar"; \
-    if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR" ]; then \
+    JDISCO_POM_M2="/root/.m2/repository/dk/ruc/keld/jdisco/${JDISCO_VERSION}/jdisco-${JDISCO_VERSION}.pom"; \
+    if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR" ] || [ ! -f "$JDISCO_POM_M2" ]; then \
         echo "kDisco 0.2.0 or jDisco ${JDISCO_VERSION} not cached — building from source..."; \
         KDISCO_COMMIT="7cb97d0cd5747972775a4719f525a19928faa92b"; \
         git clone https://github.com/bedaHovorka/kdisco.git /tmp/kdisco; \
@@ -80,8 +81,11 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
         JDISCO_POM=$(find /root/.gradle/caches/modules-2 -name "jdisco-${JDISCO_VERSION}.pom" 2>/dev/null | head -1); \
         [ -n "$JDISCO_CACHE" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.jar not found in Gradle cache"; exit 1; }; \
         [ -n "$JDISCO_POM" ]   || { echo "ERROR: jdisco-${JDISCO_VERSION}.pom not found in Gradle cache"; exit 1; }; \
-        cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" && echo "jDisco ${JDISCO_VERSION} JAR installed to mavenLocal"; \
-        cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" && echo "jDisco ${JDISCO_VERSION} POM installed to mavenLocal"; \
+        cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" || { echo "ERROR: failed to copy jdisco-${JDISCO_VERSION}.jar into mavenLocal at $JDISCO_DIR"; exit 1; }; \
+        cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" || { echo "ERROR: failed to copy jdisco-${JDISCO_VERSION}.pom into mavenLocal at $JDISCO_DIR"; exit 1; }; \
+        [ -f "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.jar" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.jar not present in mavenLocal at $JDISCO_DIR after copy"; exit 1; }; \
+        [ -f "$JDISCO_DIR/jdisco-${JDISCO_VERSION}.pom" ] || { echo "ERROR: jdisco-${JDISCO_VERSION}.pom not present in mavenLocal at $JDISCO_DIR after copy"; exit 1; }; \
+        echo "jDisco ${JDISCO_VERSION} JAR and POM installed to mavenLocal at $JDISCO_DIR"; \
     else \
         echo "kDisco 0.2.0 and jDisco ${JDISCO_VERSION} found in cache — skipping build"; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,17 @@ COPY .editorconfig /build/interlockSim/
 # kDisco 0.2.0 is not published to any public Maven repo, so it must be
 # built from source and published to mavenLocal before interlockSim compiles.
 # Building kDisco also downloads jDisco (its transitive dep) into the
-# Gradle cache, making it available for interlockSim's dependency resolution.
+# Gradle cache; jDisco is then copied to mavenLocal so Layer 5 can resolve
+# it as a transitive dep of kDisco without GitHub Packages authentication.
 # Requires outbound HTTPS to github.com on cache miss. In air-gapped environments,
 # pre-populate the BuildKit cache by running a connected build first.
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \
     KDISCO_JAR="/root/.m2/repository/cz/hovorka/kdisco/kdisco-core-api-jvm/0.2.0/kdisco-core-api-jvm-0.2.0.jar"; \
-    if [ ! -f "$KDISCO_JAR" ]; then \
-        echo "kDisco 0.2.0 not cached — building from source..."; \
+    JDISCO_JAR="/root/.m2/repository/dk/ruc/keld/jdisco/1.2.0/jdisco-1.2.0.jar"; \
+    if [ ! -f "$KDISCO_JAR" ] || [ ! -f "$JDISCO_JAR" ]; then \
+        echo "kDisco 0.2.0 or jDisco 1.2.0 not cached — building from source..."; \
         KDISCO_COMMIT="7cb97d0cd5747972775a4719f525a19928faa92b"; \
         git clone https://github.com/bedaHovorka/kdisco.git /tmp/kdisco; \
         cd /tmp/kdisco; \
@@ -71,8 +73,14 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
         GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
         ./gradlew :kdisco-core-api:publishToMavenLocal --no-daemon; \
         rm -rf /tmp/kdisco; \
+        JDISCO_DIR="/root/.m2/repository/dk/ruc/keld/jdisco/1.2.0"; \
+        mkdir -p "$JDISCO_DIR"; \
+        JDISCO_CACHE=$(find /root/.gradle/caches/modules-2 -name "jdisco-1.2.0.jar" 2>/dev/null | head -1); \
+        JDISCO_POM=$(find /root/.gradle/caches/modules-2 -name "jdisco-1.2.0.pom" 2>/dev/null | head -1); \
+        [ -n "$JDISCO_CACHE" ] && cp "$JDISCO_CACHE" "$JDISCO_DIR/jdisco-1.2.0.jar" && echo "jDisco 1.2.0 installed to mavenLocal"; \
+        [ -n "$JDISCO_POM" ]   && cp "$JDISCO_POM"   "$JDISCO_DIR/jdisco-1.2.0.pom"; \
     else \
-        echo "kDisco 0.2.0 found in cache — skipping build"; \
+        echo "kDisco 0.2.0 and jDisco 1.2.0 found in cache — skipping build"; \
     fi
 
 # Layer 3: Resolve dependencies with BuildKit cache mount


### PR DESCRIPTION
## Summary

- Fixes a Docker build gap where Layer 2.5 (kDisco build) was skipped because kDisco was in BuildKit cache, but jDisco was never installed to mavenLocal
- Layer 5 (`clean build`) then failed with `Could not find dk.ruc.keld:jdisco:1.2.0` when building any branch with changed `src/` (e.g. PR #382)
- Expands the skip condition to also check `jdisco-1.2.0.jar` in mavenLocal; if either artifact is missing, the kDisco build runs and jDisco is copied from the Gradle module cache to mavenLocal afterward

## Root cause

Layer 2.5 skipped when `KDISCO_JAR` found → jDisco never in mavenLocal.
Layer 3 (`dependencies`) hit Docker image cache → also skipped.
Layer 5 (`clean build`) ran fresh on changed `src/` → Gradle couldn't resolve jDisco.

## Fix

After the kDisco build, copy `jdisco-1.2.0.jar` and `.pom` from Gradle module cache to mavenLocal (`~/.m2/repository/dk/ruc/keld/jdisco/1.2.0/`). `mavenLocal()` is first in `build.gradle.kts` repositories so Layer 5 finds jDisco without any GitHub Packages auth.

## Test plan

- [ ] Docker build succeeds on a branch with changed `src/` (PR #382 use case)
- [ ] Docker build on `develop` (unchanged `src/`) still works
- [ ] Full cache-cold build still works (kDisco + jDisco both downloaded and installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)