### PR TITLE
chore: verify interlockSim against kdisco 0.3.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ javaVersion=21
 kotlinVersion=2.0.20
 
 # Dependency versions (updated for Java 21 compatibility)
-kdiscoVersion=0.2.0
+kdiscoVersion=0.3.0-SNAPSHOT
 slf4jVersion=2.0.17
 logbackVersion=1.5.23
 kotlinLoggingVersion=7.0.3


### PR DESCRIPTION
## Summary

- Bumps `kdiscoVersion` from `0.2.0` to `0.3.0-SNAPSHOT` to verify compatibility with the `feat/kdisco-engine-phase1` branch of kdisco
- The kdisco module was renamed (`kdisco-core-api` → `kdisco-core`) in that branch; a publishing fix in kdisco preserves the artifact ID `kdisco-core-api-jvm` so interlockSim requires only a version bump

## Verification results

- `./gradlew build` — **BUILD SUCCESSFUL**
- `./gradlew test integrationTest` — **339 tests, 0 failures, 3 skipped**
- `runEditor` and `runExampleGui -PendTime=300` — both ran cleanly

## Notes

This branch is local verification only — **do not merge**. Once kdisco 0.3.0 is released to GitHub Packages, a separate PR will bump the version to the stable release.

Depends on: bedaHovorka/kdisco#3