### PR TITLE
feat(fast-sim): add :fast-sim Gradle subproject (#414)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ For complete build system documentation including dependency management, GitHub 
 
 - `core/` - KMP `:core` subproject (domain model, simulation engine, XML)
 - `desktop-ui/` - JVM `:desktop-ui` subproject (GUI, DI bootstrap, Main entry)
+- `fast-sim/` - native `:fast-sim` subproject (linuxX64 CLI binary, **requires Linux host**)
   - `desktop-ui/src/main/kotlin/` - Main source code
   - `desktop-ui/src/test/kotlin/` - Test source code
   - `desktop-ui/src/main/resources/` - Resource files (XML examples)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ listOf(
     tasks.register(name) { dependsOn(":desktop-ui:$name") }
 }
 
-tasks.register("buildFastSim") { dependsOn(":fast-sim:linkDebugExecutableLinuxX64") }
+tasks.register("buildFastSim") { dependsOn(":fast-sim:linkDebugExecutableLinuxX64") }  // debug; flip to Release once #415 lands
 tasks.register("runFastSim") { dependsOn(":fast-sim:runDebugExecutableLinuxX64") }
 tasks.register("buildFastSimRelease") { dependsOn(":fast-sim:linkReleaseExecutableLinuxX64") }
 tasks.register("runFastSimRelease") { dependsOn(":fast-sim:runReleaseExecutableLinuxX64") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,9 @@ listOf(
 }
 
 tasks.register("buildFastSim") { dependsOn(":fast-sim:linkDebugExecutableLinuxX64") }
-tasks.register("runFastSim")   { dependsOn(":fast-sim:runDebugExecutableLinuxX64") }
+tasks.register("runFastSim") { dependsOn(":fast-sim:runDebugExecutableLinuxX64") }
+tasks.register("buildFastSimRelease") { dependsOn(":fast-sim:linkReleaseExecutableLinuxX64") }
+tasks.register("runFastSimRelease") { dependsOn(":fast-sim:runReleaseExecutableLinuxX64") }
 
 // ===========================================
 // SonarQube Configuration

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,9 @@ listOf(
     tasks.register(name) { dependsOn(":desktop-ui:$name") }
 }
 
+tasks.register("buildFastSim") { dependsOn(":fast-sim:linkDebugExecutableLinuxX64") }
+tasks.register("runFastSim")   { dependsOn(":fast-sim:runDebugExecutableLinuxX64") }
+
 // ===========================================
 // SonarQube Configuration
 // ===========================================

--- a/fast-sim/build.gradle.kts
+++ b/fast-sim/build.gradle.kts
@@ -1,0 +1,107 @@
+/*
+ * fast-sim/build.gradle.kts
+ *
+ * :fast-sim — native linuxX64 simulation CLI
+ * Compiles to a statically-linked native binary with no JVM dependency.
+ * Depends on :core (commonMain provides simulation engine, XML parsing, domain model).
+ */
+
+plugins {
+	kotlin("multiplatform")
+	id("io.gitlab.arturbosch.detekt")
+	id("org.jlleitschuh.gradle.ktlint")
+}
+
+// Load versions from root gradle.properties
+val kotlinVersion: String by project
+
+group = "cz.vutbr.fit"
+version = "1.0"
+
+kotlin {
+	// linuxX64 only — this is a native CLI binary, not a library
+	linuxX64 {
+		binaries {
+			executable {
+				entryPoint = "cz.vutbr.fit.interlockSim.fastsim.main"
+				baseName = "fast-sim"
+			}
+		}
+	}
+
+	sourceSets {
+		val linuxX64Main by getting {
+			dependencies {
+				// All simulation logic, XML parsing, Koin DI come transitively via :core
+				implementation(project(":core"))
+			}
+		}
+	}
+}
+
+// ===========================================
+// checkKdisco dependency
+// ===========================================
+
+tasks.named("compileKotlinLinuxX64") {
+	dependsOn(rootProject.tasks.named("checkKdisco"))
+}
+
+// ===========================================
+// Detekt Configuration
+// ===========================================
+
+detekt {
+	config.setFrom(files("${rootProject.projectDir}/detekt.yml"))
+	buildUponDefaultConfig = true
+	allRules = false
+	source.setFrom("src/linuxX64Main/kotlin")
+	ignoreFailures = false
+	baseline = file("${rootProject.projectDir}/detekt-baseline.xml")
+	parallel = true
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+	jvmTarget = "21"
+	reports {
+		html.required.set(true)
+		xml.required.set(true)
+		txt.required.set(true)
+		sarif.required.set(false)
+		md.required.set(false)
+	}
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+	jvmTarget = "21"
+}
+
+dependencies {
+	detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
+}
+
+// ===========================================
+// Ktlint Configuration
+// ===========================================
+
+ktlint {
+	version.set("1.5.0")
+	verbose.set(true)
+	outputToConsole.set(true)
+	outputColorName.set("AUTO")
+	enableExperimentalRules.set(false)
+	android.set(false)
+	filter {
+		exclude("**/generated/**")
+		exclude("**/build/**")
+	}
+	reporters {
+		reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
+		reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+	}
+}
+
+// Disabled for consistency with :core and :desktop-ui — see their build files for rationale.
+tasks.matching { it.name.startsWith("ktlint") && it.name.endsWith("Check") }.configureEach {
+	enabled = false
+}

--- a/fast-sim/build.gradle.kts
+++ b/fast-sim/build.gradle.kts
@@ -12,9 +12,6 @@ plugins {
 	id("org.jlleitschuh.gradle.ktlint")
 }
 
-// Load versions from root gradle.properties
-val kotlinVersion: String by project
-
 group = "cz.vutbr.fit"
 version = "1.0"
 
@@ -32,7 +29,9 @@ kotlin {
 	sourceSets {
 		val linuxX64Main by getting {
 			dependencies {
-				// All simulation logic, XML parsing, Koin DI come transitively via :core
+				// :core commonMain uses KMP artifacts with linuxX64 klibs:
+				// koin-core 3.5.6, kdisco-core 0.3.0, xmlutil:core 0.91.0-RC1,
+				// kotlin-logging 7.0.3 — all validated by :core:compileKotlinLinuxX64 passing.
 				implementation(project(":core"))
 			}
 		}
@@ -51,8 +50,10 @@ tasks.named("compileKotlinLinuxX64") {
 // Detekt Configuration
 // ===========================================
 
+// :fast-sim is entirely new Kotlin code (not converted from Java), so detekt-strict.yml applies.
+// See CLAUDE.md: "detekt-strict.yml — strict rules for new Kotlin code written from scratch".
 detekt {
-	config.setFrom(files("${rootProject.projectDir}/detekt.yml"))
+	config.setFrom(files("${rootProject.projectDir}/detekt-strict.yml"))
 	buildUponDefaultConfig = true
 	allRules = false
 	source.setFrom("src/linuxX64Main/kotlin")
@@ -62,6 +63,8 @@ detekt {
 }
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+	// Detekt runs on the JVM as a static analysis tool regardless of the compilation
+	// target. jvmTarget here refers to Detekt's analysis engine, not the native binary.
 	jvmTarget = "21"
 	reports {
 		html.required.set(true)
@@ -101,7 +104,10 @@ ktlint {
 	}
 }
 
-// Disabled for consistency with :core and :desktop-ui — see their build files for rationale.
+// Disable ktlint checks — project-wide policy (:core and :desktop-ui have the same disable block).
+// Reason: tabs per .editorconfig conflict with ktlint's default spaces rule.
+// Detekt handles structural quality checks instead.
+// TODO: Re-enable ktlint project-wide once tab/space configuration is resolved (tracked).
 tasks.matching { it.name.startsWith("ktlint") && it.name.endsWith("Check") }.configureEach {
 	enabled = false
 }

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
@@ -1,0 +1,11 @@
+package cz.vutbr.fit.interlockSim.fastsim
+
+/**
+ * Entry point for the :fast-sim native CLI binary.
+ *
+ * Stub — full implementation in sub-issue #415
+ * (NativeContextFactory + NativeExampleRegistry + EmbeddedResources).
+ */
+fun main(args: Array<String>) {
+	println("fast-sim: not yet implemented (args=${args.toList()})")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ rootProject.name = "interlockSim"
 
 include(":core")
 include(":desktop-ui")
+include(":fast-sim")
 
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)


### PR DESCRIPTION
## Summary

- Adds `:fast-sim` KMP subproject with `linuxX64` executable target
- `fast-sim/build.gradle.kts`: `kotlin("multiplatform")`, linuxX64 binary (entryPoint `fastsim.main`, baseName `fast-sim`), depends on `:core`, detekt + ktlint configured
- `fast-sim/src/linuxX64Main/.../Main.kt`: stub entry point (will be replaced in #415)
- `settings.gradle.kts`: `include(":fast-sim")`
- Root `build.gradle.kts`: `buildFastSim` and `runFastSim` delegation tasks

## Part of epic #413

Dependency order: **#414** → #415 → #416 → #417

## Test plan

- [x] `./gradlew :fast-sim:linkDebugExecutableLinuxX64` succeeds
- [x] `./fast-sim/build/bin/linuxX64/debugExecutable/fast-sim.kexe` runs and prints stub message
- [x] `./gradlew build` passes (56 tasks, 0 failures)

Closes #414 

🤖 Generated with [Claude Code](https://claude.com/claude-code)