### PR TITLE
feat(fast-sim): Docker image — minimal native container (#419)

### DIFF
--- a/Dockerfile.fast-sim
+++ b/Dockerfile.fast-sim
@@ -23,11 +23,6 @@
 # Debian bookworm only ships openjdk-17, but Gradle + Kotlin require JDK 21.
 FROM eclipse-temurin:21-jdk AS builder
 
-# Build arguments for GitHub Packages authentication
-# Required to download kdisco-core from GitHub Packages (bedaHovorka/kdisco)
-ARG GITHUB_ACTOR
-ARG GITHUB_TOKEN
-
 # Install git and native build dependencies
 # libxml2-dev: cinterop headers for Kotlin/Native libxml2 bindings
 # libicu-dev: transitive dependency of libxml2-dev on Debian
@@ -65,8 +60,7 @@ COPY docker-kdisco/ /root/kdisco-prebuild/
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \
-    cp -rn /root/kdisco-prebuild/. /root/.m2/repository/ && \
-    GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
+    cp -r /root/kdisco-prebuild/. /root/.m2/repository/ && \
     ./gradlew dependencies --no-daemon --warning-mode=summary
 
 # Layer 4: Copy source code (changes most frequently)
@@ -82,8 +76,7 @@ ENV GRADLE_OPTS="-Xmx2g"
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.m2/repository \
-    cp -rn /root/kdisco-prebuild/. /root/.m2/repository/ && \
-    GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
+    cp -r /root/kdisco-prebuild/. /root/.m2/repository/ && \
     ./gradlew :fast-sim:linkReleaseExecutableLinuxX64 --no-daemon --warning-mode=summary
 
 # Verify binary was created
@@ -96,7 +89,7 @@ FROM debian:bookworm-slim
 
 # Install only the runtime library the native binary links against.
 # libxml2: XML parsing via Kotlin/Native cinterop (linked with -lxml2)
-# libicu is NOT needed at runtime — only libxml2-dev pulls it in at build time.
+# Note: libxml2 depends on libicu72 transitively; apt installs it automatically.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxml2 \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.fast-sim
+++ b/Dockerfile.fast-sim
@@ -1,0 +1,109 @@
+#
+#      Brno University of Technology
+#      Faculty of Information Technology
+#
+#      BSc Thesis       2006/2007
+#
+#      Railway Interlocking Simulator
+#
+#      fast-sim: native linuxX64 CLI binary
+#      Multi-stage build: Debian Bookworm builder → bookworm-slim runtime
+#
+#      Usage:
+#        docker compose build fast-sim
+#        docker compose run fast-sim example shuntingLoop 60
+#
+
+# syntax=docker/dockerfile:1.4
+
+# ============================================
+# Stage 1: Build native binary with Gradle
+# ============================================
+# Eclipse Temurin provides JDK 21 on Debian Bookworm base.
+# Debian bookworm only ships openjdk-17, but Gradle + Kotlin require JDK 21.
+FROM eclipse-temurin:21-jdk AS builder
+
+# Build arguments for GitHub Packages authentication
+# Required to download kdisco-core from GitHub Packages (bedaHovorka/kdisco)
+ARG GITHUB_ACTOR
+ARG GITHUB_TOKEN
+
+# Install git and native build dependencies
+# libxml2-dev: cinterop headers for Kotlin/Native libxml2 bindings
+# libicu-dev: transitive dependency of libxml2-dev on Debian
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    libxml2-dev \
+    libicu-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/include/unicode /usr/include/libxml2/unicode
+
+WORKDIR /build
+
+# Layer 1: Copy Gradle wrapper files (cached until wrapper version changes)
+COPY gradlew /build/
+COPY gradlew.bat /build/
+COPY gradle/ /build/gradle/
+RUN chmod +x gradlew
+
+# Layer 2: Copy build configuration files (cached until config changes)
+COPY settings.gradle.kts /build/
+COPY gradle.properties /build/
+COPY build.gradle.kts /build/
+COPY detekt.yml /build/
+COPY detekt-strict.yml /build/
+COPY .editorconfig /build/
+COPY core/build.gradle.kts /build/core/
+COPY core-test/build.gradle.kts /build/core-test/
+COPY desktop-ui/build.gradle.kts /build/desktop-ui/
+COPY fast-sim/build.gradle.kts /build/fast-sim/
+
+# Layer 2.5: Pre-stage kDisco artifacts for offline build
+COPY docker-kdisco/ /root/kdisco-prebuild/
+
+# Layer 3: Resolve dependencies with BuildKit cache mount
+RUN --mount=type=cache,target=/root/.gradle/caches \
+    --mount=type=cache,target=/root/.gradle/wrapper \
+    --mount=type=cache,target=/root/.m2/repository \
+    cp -rn /root/kdisco-prebuild/. /root/.m2/repository/ && \
+    GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
+    ./gradlew dependencies --no-daemon --warning-mode=summary
+
+# Layer 4: Copy source code (changes most frequently)
+COPY core/src/ /build/core/src/
+COPY core-test/src/ /build/core-test/src/
+COPY fast-sim/src/ /build/fast-sim/src/
+# desktop-ui source needed for Gradle configuration resolution (settings.gradle.kts includes it)
+# but not compiled — only an empty placeholder is required.
+RUN mkdir -p /build/desktop-ui/src/main/kotlin
+
+# Layer 5: Build release native binary
+ENV GRADLE_OPTS="-Xmx2g"
+RUN --mount=type=cache,target=/root/.gradle/caches \
+    --mount=type=cache,target=/root/.gradle/wrapper \
+    --mount=type=cache,target=/root/.m2/repository \
+    cp -rn /root/kdisco-prebuild/. /root/.m2/repository/ && \
+    GITHUB_ACTOR=${GITHUB_ACTOR} GITHUB_TOKEN=${GITHUB_TOKEN} \
+    ./gradlew :fast-sim:linkReleaseExecutableLinuxX64 --no-daemon --warning-mode=summary
+
+# Verify binary was created
+RUN ls -lh /build/fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe
+
+# ============================================
+# Stage 2: Minimal runtime image
+# ============================================
+FROM debian:bookworm-slim
+
+# Install only the runtime library the native binary links against.
+# libxml2: XML parsing via Kotlin/Native cinterop (linked with -lxml2)
+# libicu is NOT needed at runtime — only libxml2-dev pulls it in at build time.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxml2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy native binary from builder
+COPY --from=builder /build/fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe \
+    /usr/local/bin/fast-sim
+
+ENTRYPOINT ["fast-sim"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,8 +78,6 @@ services:
       context: .
       dockerfile: Dockerfile.fast-sim
       args:
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
         BUILDKIT_INLINE_CACHE: 1
     image: interlocksim-fast-sim:latest
     container_name: interlocksim-fast-sim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,22 @@ services:
     # stdin_open: true
     # tty: true
 
+  # Native fast-sim CLI binary (no JVM, minimal image)
+  # Usage:
+  #   docker compose build fast-sim
+  #   docker compose run fast-sim example shuntingLoop 60
+  fast-sim:
+    build:
+      context: .
+      dockerfile: Dockerfile.fast-sim
+      args:
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+        BUILDKIT_INLINE_CACHE: 1
+    image: interlocksim-fast-sim:latest
+    container_name: interlocksim-fast-sim
+    command: ["example", "shuntingLoop", "60"]
+
   # Build LaTeX thesis with Czech language tools
   text:
     build:


### PR DESCRIPTION
## Summary
- Add Dockerfile.fast-sim with multi-stage build (Eclipse Temurin JDK 21 builder -> debian:bookworm-slim runtime)
- Add fast-sim service to docker-compose.yml
- Native binary is 4.3 MB; runtime image is 174 MB (libxml2 + libicu account for most of the size)
- Image size exceeds the aspirational 120 MB target because libxml2 on Debian transitively requires libicu72 (~36 MB); this is an unavoidable glibc/Debian dependency

Fixes #419

## Test plan
- [x] docker compose build fast-sim succeeds
- [x] docker compose run fast-sim example shuntingLoop 60 produces simulation output
- [x] docker compose run --rm fast-sim --help prints usage
- [ ] Image size check: docker images interlocksim-fast-sim (174 MB, above 120 MB target due to libicu)

Generated with Claude Code (https://claude.com/claude-code)