### PR TITLE
fix(fast-sim): wall-time formatting uses integer arithmetic (#427)

### DIFF
--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
@@ -54,8 +54,9 @@ class TextReporter(
 	}
 
 	fun printSummary() {
-		val wallSeconds = (currentTimeMillisKMP() - startWallTime) / 1000.0
-		val wallFormatted = ((wallSeconds * 10).toLong() / 10.0).toString()
+		val wallMs = currentTimeMillisKMP() - startWallTime
+		val wallTenths = wallMs / 100 // integer tenths of seconds
+		val wallFormatted = "${wallTenths / 10}.${wallTenths % 10}"
 		output(
 			"--- Simulation complete: ${trainNames.size} trains, " +
 				"${lastSimTime}s sim time, ${wallFormatted}s wall ---"

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
@@ -55,12 +55,19 @@ class TextReporter(
 
 	fun printSummary() {
 		val wallMs = currentTimeMillisKMP() - startWallTime
-		val wallTenths = (wallMs / 100).coerceAtLeast(0) // integer tenths of seconds
-		val wallFormatted = "${wallTenths / 10}.${wallTenths % 10}"
+		val wallFormatted = formatWallTime(wallMs)
 		output(
 			"--- Simulation complete: ${trainNames.size} trains, " +
 				"${lastSimTime}s sim time, ${wallFormatted}s wall ---"
 		)
+	}
+
+	internal companion object {
+		/** Format wall-clock milliseconds as "N.D" (integer seconds with one decimal). */
+		fun formatWallTime(wallMs: Long): String {
+			val wallTenths = (wallMs / 100).coerceAtLeast(0) // integer tenths of seconds
+			return "${wallTenths / 10}.${wallTenths % 10}"
+		}
 	}
 
 	private fun formatEvent(event: SimulationEvent): String {

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporter.kt
@@ -55,7 +55,7 @@ class TextReporter(
 
 	fun printSummary() {
 		val wallMs = currentTimeMillisKMP() - startWallTime
-		val wallTenths = wallMs / 100 // integer tenths of seconds
+		val wallTenths = (wallMs / 100).coerceAtLeast(0) // integer tenths of seconds
 		val wallFormatted = "${wallTenths / 10}.${wallTenths % 10}"
 		output(
 			"--- Simulation complete: ${trainNames.size} trains, " +

--- a/core/src/commonTest/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporterTest.kt
+++ b/core/src/commonTest/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporterTest.kt
@@ -109,6 +109,22 @@ class TextReporterTest {
 	}
 
 	@Test
+	fun summaryWallTimeHasCleanDecimalFormat() {
+		val output = mutableListOf<String>()
+		val reporter = TextReporter(Verbosity.DEFAULT) { output.add(it) }
+		fireEvent(reporter, ReportType.TRAIN_EVENTS, "1.0 vlak1 approved IO1->IO2")
+		reporter.printSummary()
+		val summary = output.last()
+		// Wall time must be a clean "N.D" format (integer dot single digit), no IEEE 754 artifacts
+		val wallTimeMatch = Regex("""(\d+\.\d)s wall""").find(summary)
+		assertTrue(wallTimeMatch != null, "Summary wall time should match N.Ds format: $summary")
+		// Ensure no extra decimal digits (e.g. "3.1000000000000001")
+		val wallValue = wallTimeMatch!!.groupValues[1]
+		assertEquals(wallValue, wallValue.trimEnd('0').let { if (it.endsWith('.')) it + "0" else it },
+			"Wall time should have exactly one decimal digit: $wallValue")
+	}
+
+	@Test
 	fun nonReportTypePropertyIsIgnored() {
 		val output = mutableListOf<String>()
 		val reporter = TextReporter(Verbosity.DEFAULT) { output.add(it) }

--- a/core/src/commonTest/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporterTest.kt
+++ b/core/src/commonTest/kotlin/cz/vutbr/fit/interlockSim/sim/TextReporterTest.kt
@@ -124,6 +124,67 @@ class TextReporterTest {
 			"Wall time should have exactly one decimal digit: $wallValue")
 	}
 
+	// --- formatWallTime edge-case tests (covers coerceAtLeast and integer formatting) ---
+
+	@Test
+	fun formatWallTimeZeroMs() {
+		assertEquals("0.0", TextReporter.formatWallTime(0L))
+	}
+
+	@Test
+	fun formatWallTimeSubSecond() {
+		// 350 ms = 3 tenths → "0.3"
+		assertEquals("0.3", TextReporter.formatWallTime(350L))
+	}
+
+	@Test
+	fun formatWallTimeExactSecond() {
+		assertEquals("1.0", TextReporter.formatWallTime(1000L))
+	}
+
+	@Test
+	fun formatWallTimeOneAndAHalfSeconds() {
+		// 1500 ms = 15 tenths → "1.5"
+		assertEquals("1.5", TextReporter.formatWallTime(1500L))
+	}
+
+	@Test
+	fun formatWallTimeLargeValue() {
+		// 12345 ms = 123 tenths → "12.3"
+		assertEquals("12.3", TextReporter.formatWallTime(12345L))
+	}
+
+	@Test
+	fun formatWallTimeNegativeClampsToZero() {
+		// Negative wallMs (clock went backwards) should produce "0.0" via coerceAtLeast(0)
+		assertEquals("0.0", TextReporter.formatWallTime(-500L))
+	}
+
+	@Test
+	fun formatWallTimeSlightlyNegativeClampsToZero() {
+		// -1 ms edge case
+		assertEquals("0.0", TextReporter.formatWallTime(-1L))
+	}
+
+	@Test
+	fun formatWallTimeLargeNegativeClampsToZero() {
+		assertEquals("0.0", TextReporter.formatWallTime(-999_999L))
+	}
+
+	@Test
+	fun formatWallTimeTruncatesNotRounds() {
+		// 990 ms = 9 tenths (not 10) — truncation, not rounding
+		assertEquals("0.9", TextReporter.formatWallTime(990L))
+		// 999 ms still 9 tenths
+		assertEquals("0.9", TextReporter.formatWallTime(999L))
+	}
+
+	@Test
+	fun formatWallTimeUnder100MsIsZeroTenths() {
+		// 99 ms → 0 tenths → "0.0"
+		assertEquals("0.0", TextReporter.formatWallTime(99L))
+	}
+
 	@Test
 	fun nonReportTypePropertyIsIgnored() {
 		val output = mutableListOf<String>()


### PR DESCRIPTION
## Summary
- Replace float division in `TextReporter.printSummary()` with pure integer arithmetic
- Eliminates IEEE 754 representation issues in wall-time output
- Add test verifying wall-time format is clean decimal

Fixes #427

## Test plan
- [x] TextReporter wall-time formatting test verifies clean decimal output
- [x] `./gradlew :core:jvmTest` passes
- [x] `./gradlew :core:detekt :core:ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)