### PR TITLE
fix(core): document single-threaded contract for DefaultRailWayNetGrid (#404)

### DIFF
--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/context/BaseContext.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/context/BaseContext.kt
@@ -110,10 +110,11 @@ abstract class BaseContext<T : TrackBlock>(
 ) {
 	/**
 	 * Listeners for context change notifications.
-	 * Copy-on-write list — @Volatile guarantees visibility across threads.
-	 * Add/remove is not atomic but races are acceptable (single-threaded GUI/sim use).
+	 * Copy-on-write list for safe iteration during notification.
+	 *
+	 * **Thread safety:** Not thread-safe. All access must occur on a single thread
+	 * (editor thread during construction, or simulation thread during execution).
 	 */
-	@kotlin.concurrent.Volatile
 	private var listeners: List<ContextPropertyChangeListener> = emptyList()
 
 	/**

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/cells/DynamicRailSemaphore.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/cells/DynamicRailSemaphore.kt
@@ -44,11 +44,10 @@ sealed class DynamicRailSemaphore(
 ) : OrientedPathSeparator by staticRef,
 	DynamicPathSeparator {
 	/**
-	 * Listeners for signal state changes. Copy-on-write via @Volatile list.
-	 * Not thread-safe by design: concurrent add/remove may lose an update.
-	 * Acceptable because simulation and GUI both run single-threaded.
+	 * Listeners for signal state changes. Copy-on-write list for safe iteration during notification.
+	 *
+	 * **Thread safety:** Not thread-safe. All access must occur on the simulation thread.
 	 */
-	@kotlin.concurrent.Volatile
 	private var listeners: List<ContextPropertyChangeListener> = emptyList()
 
 	// Static properties delegated from wrapped object

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/cells/DynamicRailSwitch.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/cells/DynamicRailSwitch.kt
@@ -74,11 +74,10 @@ class DynamicRailSwitch(
 		private set
 
 	/**
-	 * Listeners for switch state changes. Copy-on-write via @Volatile list.
-	 * Not thread-safe by design: concurrent add/remove may lose an update.
-	 * Acceptable because simulation and GUI both run single-threaded.
+	 * Listeners for switch state changes. Copy-on-write list for safe iteration during notification.
+	 *
+	 * **Thread safety:** Not thread-safe. All access must occur on the simulation thread.
 	 */
-	@kotlin.concurrent.Volatile
 	private var listeners: List<ContextPropertyChangeListener> = emptyList()
 
 	/**

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/tracks/DynamicTrack.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/objects/tracks/DynamicTrack.kt
@@ -42,11 +42,10 @@ class DynamicTrack(
 	val staticRef: TrackFacility
 ) {
 	/**
-	 * Listeners for track state changes. Copy-on-write via @Volatile list.
-	 * Not thread-safe by design: concurrent add/remove may lose an update.
-	 * Acceptable because simulation and GUI both run single-threaded.
+	 * Listeners for track state changes. Copy-on-write list for safe iteration during notification.
+	 *
+	 * **Thread safety:** Not thread-safe. All access must occur on the simulation thread.
 	 */
-	@kotlin.concurrent.Volatile
 	private var listeners: List<ContextPropertyChangeListener> = emptyList()
 
 	// Static properties delegated from wrapped object


### PR DESCRIPTION
## Summary
- Remove contradictory `@kotlin.concurrent.Volatile` from listener lists in `BaseContext`, `DynamicTrack`, `DynamicRailSemaphore`, and `DynamicRailSwitch`
- Document single-threaded contract in KDoc (kDisco simulation engine is inherently single-threaded)
- Resolves thread-safety annotation inconsistency from KMP migration (PR #399)

Fixes #404

## Test plan
- [x] `./gradlew :core:jvmTest` passes (1671 tests)
- [x] `./gradlew :core:detekt` passes
- [ ] No runtime changes — documentation/annotation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)