### PR TITLE
refactor(core): decouple :core tests from :desktop-ui working directory (#400)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -44,8 +44,6 @@ kotlin {
 			}
 		}
 		testRuns["test"].executionTask.configure {
-			// Use desktop-ui dir so relative File paths like "src/test/resources/..." resolve correctly
-			workingDir = rootProject.projectDir.resolve("desktop-ui")
 			useJUnitPlatform {
 				excludeTags("integration-test")
 			}
@@ -161,9 +159,6 @@ tasks.named<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest>("
 val integrationTest by tasks.registering(Test::class) {
 	group = "verification"
 	description = "Run :core integration tests (tagged with @Tag(\"integration-test\"))"
-
-	// Use desktop-ui dir so relative File paths like "src/test/resources/..." resolve correctly
-	workingDir = rootProject.projectDir.resolve("desktop-ui")
 
 	useJUnitPlatform {
 		includeTags("integration-test")

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ConcurrentSaveTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ConcurrentSaveTest.kt
@@ -66,14 +66,14 @@ class ConcurrentSaveTest : KoinTestBase() {
 	companion object {
 		private const val TEST_FILE_PREFIX = "concurrent-test-network"
 		private const val DEFAULT_TIMEOUT_SECONDS = 10
+		private val tempDir = File(System.getProperty("java.io.tmpdir"))
 	}
 
 	@AfterEach
 	fun cleanupTestFiles() {
 		// Clean up any test files created during tests
-		val currentDir = File(".")
 		val testFiles =
-			currentDir.listFiles { _, name ->
+			tempDir.listFiles { _, name ->
 				name.startsWith(TEST_FILE_PREFIX) && name.endsWith(".xml")
 			}
 
@@ -109,7 +109,7 @@ class ConcurrentSaveTest : KoinTestBase() {
 						val context = buildMinimalEditing()
 
 						// Save to unique file
-						val file = File("$TEST_FILE_PREFIX-$threadId.xml")
+						val file = File(tempDir, "$TEST_FILE_PREFIX-$threadId.xml")
 						editingContextFactory.saveContext(context, file)
 
 						successCount.incrementAndGet()
@@ -138,7 +138,7 @@ class ConcurrentSaveTest : KoinTestBase() {
 
 		// Verify all files were created and are valid
 		for (i in 0 until threadCount) {
-			val file = File("$TEST_FILE_PREFIX-$i.xml")
+			val file = File(tempDir, "$TEST_FILE_PREFIX-$i.xml")
 			assertThat(file).exists().isFile()
 
 			// Verify file is valid XML by loading it
@@ -153,7 +153,7 @@ class ConcurrentSaveTest : KoinTestBase() {
 	@DisplayName("Concurrent saves to same file should handle gracefully")
 	fun concurrentSave_sameFile_handlesGracefully() {
 		// Arrange
-		val targetFile = File("$TEST_FILE_PREFIX-same.xml")
+		val targetFile = File(tempDir, "$TEST_FILE_PREFIX-same.xml")
 		val context = buildMinimalEditing()
 
 		val threadCount = 5
@@ -206,7 +206,7 @@ class ConcurrentSaveTest : KoinTestBase() {
 		// Arrange
 		val context = buildLinearTrack()
 
-		val file = File("$TEST_FILE_PREFIX-modify.xml")
+		val file = File(tempDir, "$TEST_FILE_PREFIX-modify.xml")
 
 		val startLatch = CountDownLatch(1)
 		val doneLatch = CountDownLatch(2)
@@ -277,7 +277,7 @@ class ConcurrentSaveTest : KoinTestBase() {
 	@DisplayName("Repeated concurrent saves should maintain consistency")
 	fun repeatedConcurrentSaves_maintainsConsistency() {
 		// Arrange
-		val targetFile = File("$TEST_FILE_PREFIX-repeated.xml")
+		val targetFile = File(tempDir, "$TEST_FILE_PREFIX-repeated.xml")
 		val context = buildMinimalEditing()
 
 		// Save initial file

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ConcurrentSaveTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ConcurrentSaveTest.kt
@@ -22,12 +22,12 @@ import cz.vutbr.fit.interlockSim.testutil.buildMinimalEditing
 import cz.vutbr.fit.interlockSim.testutil.exists
 import cz.vutbr.fit.interlockSim.testutil.isFile
 import cz.vutbr.fit.interlockSim.testutil.withMessage
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.io.TempDir
 import org.koin.test.inject
 import java.io.File
 import java.io.FileInputStream
@@ -63,25 +63,12 @@ import java.util.concurrent.atomic.AtomicInteger
 class ConcurrentSaveTest : KoinTestBase() {
 	private val editingContextFactory: EditingContextFactory by inject()
 
+	@TempDir
+	lateinit var tempDir: File
+
 	companion object {
 		private const val TEST_FILE_PREFIX = "concurrent-test-network"
 		private const val DEFAULT_TIMEOUT_SECONDS = 10
-		private val tempDir = File(System.getProperty("java.io.tmpdir"))
-	}
-
-	@AfterEach
-	fun cleanupTestFiles() {
-		// Clean up any test files created during tests
-		val testFiles =
-			tempDir.listFiles { _, name ->
-				name.startsWith(TEST_FILE_PREFIX) && name.endsWith(".xml")
-			}
-
-		if (testFiles != null) {
-			for (file in testFiles) {
-				file.delete()
-			}
-		}
 	}
 
 	@Test

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
-import java.io.File
 
 /**
  * Comprehensive unit tests for context initialization via factory pattern.
@@ -149,10 +148,11 @@ class ContextInitializationTest : KoinTestBase() {
 		@DisplayName("valid XML file loads correctly")
 		fun xmlFile_valid_loadsContext() {
 			// Arrange
-			val xmlFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml")
+			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml")
+				?: error("Test fixture not found: minimal-network.xml")
 
 			// Act
-			val context = editingContextFactory.createContext(xmlFile)
+			val context = editingContextFactory.createContext(xmlStream)
 
 			// Assert
 			assertThat(context)
@@ -173,10 +173,11 @@ class ContextInitializationTest : KoinTestBase() {
 		@DisplayName("linear track XML loads with two InOut endpoints")
 		fun linearTrackFile_loadsWithEndpoints() {
 			// Arrange
-			val xmlFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+				?: error("Test fixture not found: linear-track.xml")
 
 			// Act
-			val context = editingContextFactory.createContext(xmlFile)
+			val context = editingContextFactory.createContext(xmlStream)
 
 			// Assert
 			assertThat(context)
@@ -212,7 +213,7 @@ class ContextInitializationTest : KoinTestBase() {
 		@DisplayName("nonexistent file throws exception")
 		fun xmlFile_notFound_throwsException() {
 			// Arrange
-			val xmlFile = File("nonexistent/path/does-not-exist.xml")
+			val xmlFile = java.io.File("nonexistent/path/does-not-exist.xml")
 
 			// Act & Assert
 			assertk
@@ -231,12 +232,13 @@ class ContextInitializationTest : KoinTestBase() {
 		@DisplayName("malformed XML file throws exception")
 		fun xmlFile_malformed_throwsException() {
 			// Arrange
-			val xmlFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/invalid-malformed-xml.xml")
+			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/invalid-malformed-xml.xml")
+				?: error("Test fixture not found: invalid-malformed-xml.xml")
 
 			// Act & Assert
 			assertk
 				.assertFailure {
-					editingContextFactory.createContext(xmlFile)
+					editingContextFactory.createContext(xmlStream)
 				}.isInstanceOf(Exception::class)
 		}
 	}
@@ -249,8 +251,9 @@ class ContextInitializationTest : KoinTestBase() {
 		@BeforeEach
 		fun setUp() {
 			// Load context from linear-track.xml for state validation tests
-			val xmlFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
-			val editingContext = editingContextFactory.createContext(xmlFile) as EditingContext
+			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+				?: error("Test fixture not found: linear-track.xml")
+			val editingContext = editingContextFactory.createContext(xmlStream) as EditingContext
 			linearTrackContext = simulationContextFactory.createContext(editingContext) as DefaultSimulationContext
 		}
 

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextInitializationTest.kt
@@ -147,12 +147,10 @@ class ContextInitializationTest : KoinTestBase() {
 		@Test
 		@DisplayName("valid XML file loads correctly")
 		fun xmlFile_valid_loadsContext() {
-			// Arrange
-			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml")
-				?: error("Test fixture not found: minimal-network.xml")
-
-			// Act
-			val context = editingContextFactory.createContext(xmlStream)
+			// Arrange & Act
+			val context = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/minimal-network.xml")
+				?: error("Test fixture not found: minimal-network.xml"))
+				.use { editingContextFactory.createContext(it) }
 
 			// Assert
 			assertThat(context)
@@ -172,12 +170,10 @@ class ContextInitializationTest : KoinTestBase() {
 		@Test
 		@DisplayName("linear track XML loads with two InOut endpoints")
 		fun linearTrackFile_loadsWithEndpoints() {
-			// Arrange
-			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
-				?: error("Test fixture not found: linear-track.xml")
-
-			// Act
-			val context = editingContextFactory.createContext(xmlStream)
+			// Arrange & Act
+			val context = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+				?: error("Test fixture not found: linear-track.xml"))
+				.use { editingContextFactory.createContext(it) }
 
 			// Assert
 			assertThat(context)
@@ -231,14 +227,12 @@ class ContextInitializationTest : KoinTestBase() {
 		@Test
 		@DisplayName("malformed XML file throws exception")
 		fun xmlFile_malformed_throwsException() {
-			// Arrange
-			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/invalid-malformed-xml.xml")
-				?: error("Test fixture not found: invalid-malformed-xml.xml")
-
-			// Act & Assert
+			// Arrange & Act & Assert
 			assertk
 				.assertFailure {
-					editingContextFactory.createContext(xmlStream)
+					(javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/invalid-malformed-xml.xml")
+						?: error("Test fixture not found: invalid-malformed-xml.xml"))
+						.use { editingContextFactory.createContext(it) }
 				}.isInstanceOf(Exception::class)
 		}
 	}
@@ -251,9 +245,9 @@ class ContextInitializationTest : KoinTestBase() {
 		@BeforeEach
 		fun setUp() {
 			// Load context from linear-track.xml for state validation tests
-			val xmlStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
-				?: error("Test fixture not found: linear-track.xml")
-			val editingContext = editingContextFactory.createContext(xmlStream) as EditingContext
+			val editingContext = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+				?: error("Test fixture not found: linear-track.xml"))
+				.use { editingContextFactory.createContext(it) } as EditingContext
 			linearTrackContext = simulationContextFactory.createContext(editingContext) as DefaultSimulationContext
 		}
 

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/EagerTrackWrappingTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/EagerTrackWrappingTest.kt
@@ -111,7 +111,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - all tracks wrapped after run initialization")
 		fun vyhybnaXml_allTracksWrappedAfterRunInit() {
 			// Arrange - Load vyhybna.xml configuration
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Act - Call initializeDynamicMapping (normally called by run())
 			// We can't call run() in tests because it blocks, so we call the initialization directly
@@ -152,7 +152,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - graph contains multiple track blocks")
 		fun vyhybnaXml_graphHasMultipleTracks() {
 			// Arrange
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Act
 			val graph = context.getGraph()
@@ -169,7 +169,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@Test
 		@DisplayName("vyhybna.xml - static track blocks map to dynamic wrappers")
 		fun vyhybnaXml_staticTrackLookupsReturnDynamicWrapper() {
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			context.initializeDynamicMapping()
 
@@ -202,7 +202,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		fun initializationTimeAcceptable() {
 			// Act - Measure initialization time
 			val start = System.currentTimeMillis()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			context.initializeDynamicMapping()
 			val duration = System.currentTimeMillis() - start
 

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/EagerTrackWrappingTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/EagerTrackWrappingTest.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
-import java.io.File
 
 /**
  * Tests for Issue #214: Pre-Wrap All Tracks at Initialization
@@ -43,6 +42,10 @@ import java.io.File
 @DisplayName("Eager Track Wrapping (Issue #214)")
 class EagerTrackWrappingTest : KoinTestBase() {
 	private val factory: SimulationContextFactory by inject()
+
+	private fun loadVyhybnaStream() =
+		javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml")
 
 	@Nested
 	@DisplayName("Unit Tests - Eager Wrapping")
@@ -108,8 +111,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - all tracks wrapped after run initialization")
 		fun vyhybnaXml_allTracksWrappedAfterRunInit() {
 			// Arrange - Load vyhybna.xml configuration
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Act - Call initializeDynamicMapping (normally called by run())
 			// We can't call run() in tests because it blocks, so we call the initialization directly
@@ -150,8 +152,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - graph contains multiple track blocks")
 		fun vyhybnaXml_graphHasMultipleTracks() {
 			// Arrange
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Act
 			val graph = context.getGraph()
@@ -168,8 +169,7 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@Test
 		@DisplayName("vyhybna.xml - static track blocks map to dynamic wrappers")
 		fun vyhybnaXml_staticTrackLookupsReturnDynamicWrapper() {
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			context.initializeDynamicMapping()
 
@@ -200,12 +200,9 @@ class EagerTrackWrappingTest : KoinTestBase() {
 		@Test
 		@DisplayName("initialization time acceptable for vyhybna.xml")
 		fun initializationTimeAcceptable() {
-			// Arrange
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-
 			// Act - Measure initialization time
 			val start = System.currentTimeMillis()
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			context.initializeDynamicMapping()
 			val duration = System.currentTimeMillis() - start
 

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/SimulationGridDynamicCellsTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/SimulationGridDynamicCellsTest.kt
@@ -81,7 +81,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `simulation grid stores DynamicRailSemaphore not static RailSemaphore`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find any semaphore cell in the grid
@@ -111,7 +111,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all semaphores in simulation grid are dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are instances of DynamicRailSemaphore
@@ -148,7 +148,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `simulation grid stores DynamicInOut not static InOut`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find any InOut cell in the grid
@@ -178,7 +178,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all InOuts in simulation grid are dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are instances of DynamicInOut
@@ -214,7 +214,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid navigation returns dynamic wrappers directly`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find position of any semaphore in grid
@@ -245,7 +245,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid navigation returns same instance on repeated calls`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Find any semaphore position
@@ -287,7 +287,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all NodeCells in simulation grid are dynamic wrappers`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are DynamicPathSeparator instances
@@ -321,7 +321,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `TrackBlockPart cells are not transformed to dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all TrackBlockPart cells
@@ -357,7 +357,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid contains both dynamic NodeCells and static TrackBlockPart`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Count dynamic NodeCells and static TrackBlockPart
@@ -395,7 +395,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `staticToDynamicMap contains mappings for all NodeCells`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Act: Access staticToDynamicMap via reflection (it's private)
 			val staticToDynamicMapField =
@@ -427,7 +427,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `toDynamic returns same instance as grid navigation`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Find a semaphore in the grid

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/SimulationGridDynamicCellsTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/SimulationGridDynamicCellsTest.kt
@@ -23,7 +23,6 @@ import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.io.File
 
 /**
  * Test suite for Issue #280/#281: Verify that DefaultSimulationContext.fromEditingContext()
@@ -58,11 +57,9 @@ import java.io.File
  */
 @DisplayName("Simulation Grid Dynamic Cells Verification (Issue #281)")
 class SimulationGridDynamicCellsTest : KoinTestBase() {
-	companion object {
-		// Path to vyhybna.xml test fixture (shunting loop configuration)
-		private val VYHYBNA_XML_PATH =
-			"src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml"
-	}
+	private fun loadVyhybnaStream() =
+		javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml")
 
 	@Nested
 	@DisplayName("Dynamic semaphore storage")
@@ -84,7 +81,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `simulation grid stores DynamicRailSemaphore not static RailSemaphore`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find any semaphore cell in the grid
@@ -114,7 +111,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all semaphores in simulation grid are dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are instances of DynamicRailSemaphore
@@ -151,7 +148,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `simulation grid stores DynamicInOut not static InOut`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find any InOut cell in the grid
@@ -181,7 +178,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all InOuts in simulation grid are dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are instances of DynamicInOut
@@ -217,7 +214,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid navigation returns dynamic wrappers directly`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find position of any semaphore in grid
@@ -248,7 +245,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid navigation returns same instance on repeated calls`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Find any semaphore position
@@ -290,7 +287,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `all NodeCells in simulation grid are dynamic wrappers`() {
 			// Arrange: Load vyhybna.xml and create simulation context
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all cells that are DynamicPathSeparator instances
@@ -324,7 +321,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `TrackBlockPart cells are not transformed to dynamic wrappers`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Find all TrackBlockPart cells
@@ -360,7 +357,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `grid contains both dynamic NodeCells and static TrackBlockPart`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Act: Count dynamic NodeCells and static TrackBlockPart
@@ -398,7 +395,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `staticToDynamicMap contains mappings for all NodeCells`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Act: Access staticToDynamicMap via reflection (it's private)
 			val staticToDynamicMapField =
@@ -430,7 +427,7 @@ class SimulationGridDynamicCellsTest : KoinTestBase() {
 		fun `toDynamic returns same instance as grid navigation`() {
 			// Arrange
 			val factory = getKoin().get<SimulationContextFactory>()
-			val context = factory.createContext(File(VYHYBNA_XML_PATH)) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 			val grid = context.getRailWayNetGrid()
 
 			// Find a semaphore in the grid

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/TrackDynamicMappingTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/TrackDynamicMappingTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
-import java.io.File
 
 /**
  * Tests for Track-to-Dynamic mapping in SimulationContext
@@ -39,6 +38,10 @@ import java.io.File
 @DisplayName("Track-to-Dynamic Mapping")
 class TrackDynamicMappingTest : KoinTestBase() {
 	private val factory: SimulationContextFactory by inject()
+
+	private fun loadVyhybnaStream() =
+		javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml")
 
 	@Nested
 	@DisplayName("Unit Tests - Track Mapping")
@@ -70,8 +73,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		fun toDynamic_unmappedTrack_throwsException() {
 			// Arrange
 			val context = factory.createEmptyContext()
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val contextWithTracks = factory.createContext(xmlFile) as DefaultSimulationContext
+			val contextWithTracks = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Get a track from the context with tracks
 			val graph = contextWithTracks.getGraph()
@@ -101,8 +103,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - track mapping with eager creation")
 		fun vyhybnaXml_trackMappingEagerCreation() {
 			// Arrange - Load vyhybna.xml configuration
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Initialize dynamic mapping (normally called by run())
 			context.initializeDynamicMapping()
@@ -140,8 +141,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - graph contains multiple track blocks")
 		fun vyhybnaXml_graphHasMultipleTracks() {
 			// Arrange
-			val xmlFile = File("src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			val context = factory.createContext(xmlFile) as DefaultSimulationContext
+			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
 
 			// Act
 			val graph = context.getGraph()

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/TrackDynamicMappingTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/TrackDynamicMappingTest.kt
@@ -73,7 +73,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		fun toDynamic_unmappedTrack_throwsException() {
 			// Arrange
 			val context = factory.createEmptyContext()
-			val contextWithTracks = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val contextWithTracks = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Get a track from the context with tracks
 			val graph = contextWithTracks.getGraph()
@@ -103,7 +103,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - track mapping with eager creation")
 		fun vyhybnaXml_trackMappingEagerCreation() {
 			// Arrange - Load vyhybna.xml configuration
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Initialize dynamic mapping (normally called by run())
 			context.initializeDynamicMapping()
@@ -141,7 +141,7 @@ class TrackDynamicMappingTest : KoinTestBase() {
 		@DisplayName("vyhybna.xml - graph contains multiple track blocks")
 		fun vyhybnaXml_graphHasMultipleTracks() {
 			// Arrange
-			val context = factory.createContext(loadVyhybnaStream()) as DefaultSimulationContext
+			val context = loadVyhybnaStream().use { factory.createContext(it) } as DefaultSimulationContext
 
 			// Act
 			val graph = context.getGraph()

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/SwitchConfigurationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/SwitchConfigurationTest.kt
@@ -65,10 +65,9 @@ class SwitchConfigurationTest : KoinTestBase() {
 
 	@BeforeEach
 	fun setUp() {
-		val resourceStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-			?: error("Resource not found: vyhybna.xml")
-
-		val editingContext = editingContextFactory.createContext(resourceStream) as EditingContext
+		val editingContext = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml"))
+			.use { editingContextFactory.createContext(it) } as EditingContext
 		context = ContextTransformer.createSimulationContext(editingContext, processFactory)
 
 		// Get elements from grid by coordinates (same as ShuntingLoop)

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/SwitchConfigurationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/SwitchConfigurationTest.kt
@@ -21,7 +21,6 @@ import cz.vutbr.fit.interlockSim.objects.core.ContextChangeEvent
 import cz.vutbr.fit.interlockSim.objects.core.ContextPropertyChangeListener
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
-import java.io.File
 
 /**
  * Unit tests for switch configuration during path reservation.
@@ -66,10 +65,10 @@ class SwitchConfigurationTest : KoinTestBase() {
 
 	@BeforeEach
 	fun setUp() {
-		val resourcePath = javaClass.getResource("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
-		assertThat(resourcePath).isNotNull()
+		val resourceStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml")
 
-		val editingContext = editingContextFactory.createContext(File(resourcePath!!.path)) as EditingContext
+		val editingContext = editingContextFactory.createContext(resourceStream) as EditingContext
 		context = ContextTransformer.createSimulationContext(editingContext, processFactory)
 
 		// Get elements from grid by coordinates (same as ShuntingLoop)

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/PathTrackIntegrationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/PathTrackIntegrationTest.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
-import java.io.File
 
 /**
  * Integration tests for path-track coordination in railway interlocking.
@@ -66,13 +65,15 @@ class PathTrackIntegrationTest : KoinTestBase() {
 
 	@BeforeEach
 	fun setUp() {
-		// Load XML fixtures for testing
-		val linearFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
-		val switchFile = File("src/test/resources/cz/vutbr/fit/interlockSim/xml/fixtures/switch-basic.xml")
+		// Load XML fixtures for testing via classpath resources
+		val linearStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+			?: error("Test fixture not found: linear-track.xml")
+		val switchStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/switch-basic.xml")
+			?: error("Test fixture not found: switch-basic.xml")
 
 		// Create contexts from fixtures (will be wrapped in MockSimulationContext as needed)
-		linearContext = simulationContextFactory.createContext(linearFile) as DefaultSimulationContext
-		switchContext = simulationContextFactory.createContext(switchFile) as DefaultSimulationContext
+		linearContext = simulationContextFactory.createContext(linearStream) as DefaultSimulationContext
+		switchContext = simulationContextFactory.createContext(switchStream) as DefaultSimulationContext
 
 		// Initialize dynamic mappings for both contexts
 		// This is required because tests use toDynamic() without calling run()

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/PathTrackIntegrationTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/PathTrackIntegrationTest.kt
@@ -66,14 +66,12 @@ class PathTrackIntegrationTest : KoinTestBase() {
 	@BeforeEach
 	fun setUp() {
 		// Load XML fixtures for testing via classpath resources
-		val linearStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
-			?: error("Test fixture not found: linear-track.xml")
-		val switchStream = javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/switch-basic.xml")
-			?: error("Test fixture not found: switch-basic.xml")
-
-		// Create contexts from fixtures (will be wrapped in MockSimulationContext as needed)
-		linearContext = simulationContextFactory.createContext(linearStream) as DefaultSimulationContext
-		switchContext = simulationContextFactory.createContext(switchStream) as DefaultSimulationContext
+		linearContext = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/linear-track.xml")
+			?: error("Test fixture not found: linear-track.xml"))
+			.use { simulationContextFactory.createContext(it) as DefaultSimulationContext }
+		switchContext = (javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/xml/fixtures/switch-basic.xml")
+			?: error("Test fixture not found: switch-basic.xml"))
+			.use { simulationContextFactory.createContext(it) as DefaultSimulationContext }
 
 		// Initialize dynamic mappings for both contexts
 		// This is required because tests use toDynamic() without calling run()

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/JvmParityReferenceTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/JvmParityReferenceTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import java.io.File
 import java.util.concurrent.TimeUnit
 
 /**
@@ -50,8 +49,7 @@ class JvmParityReferenceTest : KoinTestBase() {
 
 	companion object {
 		private const val END_TIME = 60L
-		private val VYHYBNA_XML_PATH =
-			"src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml"
+		private const val VYHYBNA_RESOURCE = "/cz/vutbr/fit/interlockSim/resource/vyhybna.xml"
 		private val timestampRegex = Regex("""t=([\d.]+)\s+""")
 	}
 
@@ -62,8 +60,10 @@ class JvmParityReferenceTest : KoinTestBase() {
 	 */
 	private fun runSimulationAndCollect(): Pair<List<String>, String> {
 		val factory = getKoin().get<SimulationContextFactory>()
+		val stream = javaClass.getResourceAsStream(VYHYBNA_RESOURCE)
+			?: throw IllegalStateException("Classpath resource not found: $VYHYBNA_RESOURCE")
 		val context = Util.assertInstanceOf<DefaultSimulationContext>(
-			factory.createContext(File(VYHYBNA_XML_PATH))
+			stream.use { factory.createContext(it) }
 		)
 		context.getInOuts()
 		context.setMainProcess(ShuntingLoop(context, END_TIME))

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopSmokeTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopSmokeTest.kt
@@ -101,9 +101,11 @@ class ShuntingLoopSmokeTest : KoinTestBase() {
 	private fun createConfiguredSimulation(endTime: Long): SimulationContext {
 		val factory = getKoin().get<SimulationContextFactory>()
 		val context =
-			Util.assertInstanceOf<DefaultSimulationContext>(
-				factory.createContext(loadVyhybnaStream())
-			)
+			loadVyhybnaStream().use { stream ->
+				Util.assertInstanceOf<DefaultSimulationContext>(
+					factory.createContext(stream)
+				)
+			}
 
 		// Initialize dynamic wrapper map by calling getInOuts()
 		context.getInOuts()

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopSmokeTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoopSmokeTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import java.io.File
 import java.util.concurrent.TimeUnit
 
 /**
@@ -76,10 +75,6 @@ class ShuntingLoopSmokeTest : KoinTestBase() {
 	companion object {
 		private val logger = KotlinLogging.logger {}
 
-		// Path to vyhybna.xml test fixture (shunting loop configuration)
-		private val VYHYBNA_XML_PATH =
-			"src/main/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml"
-
 		/**
 		 * Standard simulation end time for integration tests requiring both trains to complete.
 		 *
@@ -99,11 +94,15 @@ class ShuntingLoopSmokeTest : KoinTestBase() {
 	 * @param endTime Simulation end time in seconds
 	 * @return Configured simulation context with ShuntingLoop as main process
 	 */
+	private fun loadVyhybnaStream() =
+		javaClass.getResourceAsStream("/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
+			?: error("Resource not found: vyhybna.xml")
+
 	private fun createConfiguredSimulation(endTime: Long): SimulationContext {
 		val factory = getKoin().get<SimulationContextFactory>()
 		val context =
 			Util.assertInstanceOf<DefaultSimulationContext>(
-				factory.createContext(File(VYHYBNA_XML_PATH))
+				factory.createContext(loadVyhybnaStream())
 			)
 
 		// Initialize dynamic wrapper map by calling getInOuts()


### PR DESCRIPTION
## Summary
- Replace filesystem-relative `File()` paths with classpath resource loading (`getResourceAsStream`) in 8 test files
- Remove `workingDir` override from `core/build.gradle.kts` for both unit and integration test tasks
- Use `java.io.tmpdir` for `ConcurrentSaveTest` temp files instead of CWD
- Prerequisite for #401 (commonTest migration) and #410 (native test coverage)

Fixes #400

## Test plan
- [x] `./gradlew :core:jvmTest` — all 1671 core unit tests pass without desktop-ui workingDir
- [x] `./gradlew :core:integrationTest` — all 150 integration tests pass
- [x] `./gradlew clean build` — full build passes (including :desktop-ui and :fast-sim)
- [x] `./gradlew :core:detekt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)