### PR TITLE
ci(fast-sim): build & test native binary in GitHub Actions (#420)

### DIFF
--- a/.github/workflows/gradle-java21.yml
+++ b/.github/workflows/gradle-java21.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'ci/**', 'copilot/**', 'claude/**' ]
   pull_request:
-    branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'ci/**', 'copilot/**', 'claude/**' ]
+    branches: [ main, develop, 'feature/**', 'feat/**' ]
   workflow_dispatch:  # Allow manual trigger
 
 permissions:
@@ -214,7 +214,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: wrapper
-        cache-read-only: true
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
         build-scan-publish: true
         build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
         build-scan-terms-of-use-agree: "yes"
@@ -234,13 +234,18 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./gradlew :fast-sim:linkReleaseExecutableLinuxX64 --no-daemon --stacktrace
 
-    - name: Sanity check — print version
+    - name: Sanity check — verify version
       run: |
         BINARY=fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe
         echo "Binary path: $BINARY"
         echo "Binary size: $(stat --format='%s' "$BINARY" | numfmt --to=iec-i --suffix=B)"
         echo ""
-        "$BINARY" --version
+        VERSION=$("$BINARY" --version)
+        echo "Binary version: $VERSION"
+        if ! echo "$VERSION" | grep -q 'fast-sim'; then
+          echo "ERROR: --version output does not contain 'fast-sim'. Actual output: '$VERSION'"
+          exit 1
+        fi
 
     - name: Upload fast-sim native binary
       uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-java21.yml
+++ b/.github/workflows/gradle-java21.yml
@@ -2,9 +2,9 @@ name: Gradle Build with Kotlin 2.0 and Java 21
 
 on:
   push:
-    branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'copilot/**', 'claude/**' ]
+    branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'ci/**', 'copilot/**', 'claude/**' ]
   pull_request:
-    branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'copilot/**', 'claude/**' ]
+    branches: [ main, develop, 'feature/**', 'feat/**', 'fix/**', 'ci/**', 'copilot/**', 'claude/**' ]
   workflow_dispatch:  # Allow manual trigger
 
 permissions:
@@ -189,3 +189,78 @@ jobs:
           echo "✗ Smoke test failed with exit code: $EXIT_CODE"
           exit $EXIT_CODE
         fi
+
+  fast-sim:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK ${{ env.JAVA_VERSION }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+
+    - name: Install kDisco 0.3.0 artifacts from repository
+      run: |
+        mkdir -p ~/.m2/repository/cz/hovorka/kdisco
+        cp -r docker-kdisco/cz/hovorka/kdisco/. ~/.m2/repository/cz/hovorka/kdisco/
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: wrapper
+        cache-read-only: true
+        build-scan-publish: true
+        build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+        build-scan-terms-of-use-agree: "yes"
+
+    - name: Make Gradle wrapper executable
+      run: chmod +x gradlew
+
+    - name: Install libxml2 development headers
+      run: |
+        sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-dev libicu-dev
+        sudo ln -sf /usr/include/unicode /usr/include/libxml2/unicode
+
+    - name: Build fast-sim native binary (release)
+      timeout-minutes: 20
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew :fast-sim:linkReleaseExecutableLinuxX64 --no-daemon --stacktrace
+
+    - name: Sanity check — print version
+      run: |
+        BINARY=fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe
+        echo "Binary path: $BINARY"
+        echo "Binary size: $(stat --format='%s' "$BINARY" | numfmt --to=iec-i --suffix=B)"
+        echo ""
+        "$BINARY" --version
+
+    - name: Upload fast-sim native binary
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: fast-sim-linux-x64-${{ github.sha }}
+        path: fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe
+        retention-days: 30
+        if-no-files-found: error
+        compression-level: 9
+
+    - name: Add fast-sim summary
+      if: success()
+      run: |
+        BINARY=fast-sim/build/bin/linuxX64/releaseExecutable/fast-sim.kexe
+        SIZE=$(stat --format='%s' "$BINARY" | numfmt --to=iec-i --suffix=B)
+        VERSION=$("$BINARY" --version)
+        echo "## fast-sim Native Binary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
+        echo "**Size:** $SIZE" >> $GITHUB_STEP_SUMMARY
+        echo "**Artifact:** fast-sim-linux-x64-${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Retention:** 30 days" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add fast-sim job to the existing gradle-java21.yml CI workflow that builds the native linuxX64 binary, runs a --version sanity check, and uploads the .kexe as a 30-day artifact
- Job depends on build (shares Gradle cache) and installs libxml2-dev + kDisco mavenLocal artifacts
- Add ci/** to branch trigger patterns so CI branches are covered

## Test plan
- [ ] CI workflow triggers on this PR branch push
- [ ] build job passes (existing tests unaffected)
- [ ] fast-sim job builds the release binary successfully
- [ ] Sanity check prints fast-sim 1.0
- [ ] Binary artifact is uploaded with correct name

Generated with [Claude Code](https://claude.com/claude-code)