### PR TITLE
feat(fast-sim): guard ShuntingLoop against incompatible networks (#435)

### DIFF
--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoop.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoop.kt
@@ -95,6 +95,30 @@ class ShuntingLoop(
 			ReportType.TRAIN_CONTINUOUS,
 			ReportType.NODE_EVENTS
 		)
+
+		// Vyhybna network coordinate contract.
+		// Single source of truth: ShuntingLoop.init uses these and
+		// ShuntingLoopNetworkValidator (in :fast-sim) iterates them.
+		const val COORD_IN_A_X = 11
+		const val COORD_IN_A_Y = 8
+		const val COORD_IN_B_X = 30
+		const val COORD_IN_B_Y = 8
+		const val COORD_SW_A_X = 15
+		const val COORD_SW_A_Y = 8
+		const val COORD_SW_B_X = 26
+		const val COORD_SW_B_Y = 8
+		const val COORD_SEM_ZA_X = 14
+		const val COORD_SEM_ZA_Y = 8
+		const val COORD_SEM_DOA1_X = 16
+		const val COORD_SEM_DOA1_Y = 8
+		const val COORD_SEM_DOA2_X = 17
+		const val COORD_SEM_DOA2_Y = 9
+		const val COORD_SEM_DOB1_X = 25
+		const val COORD_SEM_DOB1_Y = 8
+		const val COORD_SEM_DOB2_X = 24
+		const val COORD_SEM_DOB2_Y = 9
+		const val COORD_SEM_ZB_X = 27
+		const val COORD_SEM_ZB_Y = 8
 	}
 
 	// fronta neodsouhlasenych - za jinych okolnosti seznam ze ktereho si dispecer vybere
@@ -158,16 +182,16 @@ class ShuntingLoop(
 		}
 		// Sit jiz musi byt nactena z vyhybna.xml !!!
 
-		val B: DynamicInOut = elementAt<DynamicInOut>(context, 30, 8)
-		val A: DynamicInOut = elementAt<DynamicInOut>(context, 11, 8)
-		val zA: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 14, 8)
-		val doA1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 16, 8)
-		val doB1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 25, 8)
-		val zB: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 27, 8)
-		val doA2: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 17, 9)
-		val doB2: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, 24, 9)
-		val vA: DynamicRailSwitch = elementAt<DynamicRailSwitch>(context, 15, 8)
-		val vB: DynamicRailSwitch = elementAt<DynamicRailSwitch>(context, 26, 8)
+		val B: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_B_X, COORD_IN_B_Y)
+		val A: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_A_X, COORD_IN_A_Y)
+		val zA: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_ZA_X, COORD_SEM_ZA_Y)
+		val doA1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOA1_X, COORD_SEM_DOA1_Y)
+		val doB1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOB1_X, COORD_SEM_DOB1_Y)
+		val zB: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_ZB_X, COORD_SEM_ZB_Y)
+		val doA2: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOA2_X, COORD_SEM_DOA2_Y)
+		val doB2: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOB2_X, COORD_SEM_DOB2_Y)
+		val vA: DynamicRailSwitch = elementAt<DynamicRailSwitch>(context, COORD_SW_A_X, COORD_SW_A_Y)
+		val vB: DynamicRailSwitch = elementAt<DynamicRailSwitch>(context, COORD_SW_B_X, COORD_SW_B_Y)
 
 		val k1: DynamicTrackBlock = getBlock(context, "k1", doA1, doB1)
 		val k2: DynamicTrackBlock = getBlock(context, "k2", doA2, doB2)

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoop.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/ShuntingLoop.kt
@@ -182,8 +182,8 @@ class ShuntingLoop(
 		}
 		// Sit jiz musi byt nactena z vyhybna.xml !!!
 
-		val B: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_B_X, COORD_IN_B_Y)
-		val A: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_A_X, COORD_IN_A_Y)
+		val inB: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_B_X, COORD_IN_B_Y)
+		val inA: DynamicInOut = elementAt<DynamicInOut>(context, COORD_IN_A_X, COORD_IN_A_Y)
 		val zA: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_ZA_X, COORD_SEM_ZA_Y)
 		val doA1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOA1_X, COORD_SEM_DOA1_Y)
 		val doB1: DynamicRailSemaphore = elementAt<DynamicRailSemaphore>(context, COORD_SEM_DOB1_X, COORD_SEM_DOB1_Y)
@@ -195,8 +195,8 @@ class ShuntingLoop(
 
 		val k1: DynamicTrackBlock = getBlock(context, "k1", doA1, doB1)
 		val k2: DynamicTrackBlock = getBlock(context, "k2", doA2, doB2)
-		val kA: DynamicTrackBlock = getBlock(context, "kA", A, zA)
-		val kB: DynamicTrackBlock = getBlock(context, "kB", B, zB)
+		val kA: DynamicTrackBlock = getBlock(context, "kA", inA, zA)
+		val kB: DynamicTrackBlock = getBlock(context, "kB", inB, zB)
 
 		// Issue #296: Removed manual path construction (~100 lines)
 		// Paths are now discovered dynamically using TopologyNavigator when needed

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
@@ -206,11 +206,11 @@ private fun runSim(args: Array<String>, factory: NativeContextFactory, verbosity
 	if (issues.isNotEmpty()) {
 		ctx.close()
 		eprintln("Error: network is not vyhybna-compatible (required by ShuntingLoop process)")
-		eprintln("  Missing elements:")
+		eprintln("  Issues:")
 		for (issue in issues) {
 			eprintln("    - $issue")
 		}
-		eprintln("  Canonical example: src/main/resources/cz/vutbr/fit/interlockSim/xml/vyhybna.xml")
+		eprintln("  Canonical example: core/src/jvmMain/resources/cz/vutbr/fit/interlockSim/resource/vyhybna.xml")
 		return 2
 	}
 	val reporter = TextReporter(verbosity)

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/Main.kt
@@ -202,6 +202,17 @@ private fun runSim(args: Array<String>, factory: NativeContextFactory, verbosity
 		return 2
 	}
 	val ctx = factory.createFromFile(path)
+	val issues = ShuntingLoopNetworkValidator.validateVyhybnaCompatible(ctx)
+	if (issues.isNotEmpty()) {
+		ctx.close()
+		eprintln("Error: network is not vyhybna-compatible (required by ShuntingLoop process)")
+		eprintln("  Missing elements:")
+		for (issue in issues) {
+			eprintln("    - $issue")
+		}
+		eprintln("  Canonical example: src/main/resources/cz/vutbr/fit/interlockSim/xml/vyhybna.xml")
+		return 2
+	}
 	val reporter = TextReporter(verbosity)
 	ctx.addPropertyChangeListener(reporter)
 	try {

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
@@ -1,0 +1,72 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator
+ *
+ * Bedrich Hovorka
+ */
+package cz.vutbr.fit.interlockSim.fastsim
+
+import cz.vutbr.fit.interlockSim.context.SimulationEnvironment
+import cz.vutbr.fit.interlockSim.objects.cells.DynamicInOut
+import cz.vutbr.fit.interlockSim.objects.cells.DynamicRailSemaphore
+import cz.vutbr.fit.interlockSim.objects.cells.DynamicRailSwitch
+import kotlin.reflect.KClass
+
+/**
+ * Validates that a loaded [SimulationEnvironment] has the grid elements the
+ * [cz.vutbr.fit.interlockSim.sim.ShuntingLoop] process expects at fixed coordinates.
+ *
+ * Required by Issue #435 — previously, loading a non-vyhybna-compatible network
+ * caused a confusing cast/IllegalArgument crash inside ShuntingLoop's init block.
+ * This validator fails fast with an actionable error before ShuntingLoop is constructed.
+ *
+ * @since Issue #435
+ */
+internal object ShuntingLoopNetworkValidator {
+
+	private data class Required(val x: Int, val y: Int, val expected: KClass<*>, val label: String)
+
+	private const val LABEL_IN_OUT = "InOut"
+	private const val LABEL_SWITCH = "RailSwitch"
+	private const val LABEL_SEMAPHORE = "RailSemaphore"
+
+	// Coordinates are ShuntingLoop's hardcoded vyhybna.xml lookups (see ShuntingLoop.init).
+	// They must exactly match that contract, so extracting them to named constants
+	// would only duplicate labels already present in the Required.label field.
+	@Suppress("MagicNumber")
+	private val REQUIRED_CELLS: List<Required> = listOf(
+		Required(11, 8, DynamicInOut::class, LABEL_IN_OUT),
+		Required(30, 8, DynamicInOut::class, LABEL_IN_OUT),
+		Required(15, 8, DynamicRailSwitch::class, LABEL_SWITCH),
+		Required(26, 8, DynamicRailSwitch::class, LABEL_SWITCH),
+		Required(14, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(16, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(17, 9, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(24, 9, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(25, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(27, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+	)
+
+	/**
+	 * Checks whether the environment's grid has all cells ShuntingLoop requires.
+	 *
+	 * @return list of human-readable issue strings; empty when the network is compatible.
+	 */
+	fun validateVyhybnaCompatible(context: SimulationEnvironment): List<String> {
+		val grid = context.getRailWayNetGrid()
+		val issues = mutableListOf<String>()
+		for (req in REQUIRED_CELLS) {
+			val cell = grid.getCellAt(req.x, req.y)
+			if (cell == null) {
+				issues.add("(${req.x}, ${req.y}): expected ${req.label}, but cell is missing")
+			} else if (!req.expected.isInstance(cell)) {
+				val actual = cell::class.simpleName ?: "unknown"
+				issues.add("(${req.x}, ${req.y}): expected ${req.label}, but found $actual")
+			}
+		}
+		return issues
+	}
+}

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
@@ -20,8 +20,10 @@ import kotlin.reflect.KClass
  * [cz.vutbr.fit.interlockSim.sim.ShuntingLoop] process expects at fixed coordinates.
  *
  * Required by Issue #435 — previously, loading a non-vyhybna-compatible network
- * caused a confusing cast/IllegalArgument crash inside ShuntingLoop's init block.
- * This validator fails fast with an actionable error before ShuntingLoop is constructed.
+ * failed confusingly inside ShuntingLoop's init block: missing cells led to
+ * IllegalArgumentException, while wrong-type cells failed via Util.assertInstanceOf
+ * with IllegalStateException. This validator fails fast with an actionable error
+ * before ShuntingLoop is constructed.
  *
  * @since Issue #435
  */

--- a/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
+++ b/fast-sim/src/linuxX64Main/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidator.kt
@@ -13,6 +13,7 @@ import cz.vutbr.fit.interlockSim.context.SimulationEnvironment
 import cz.vutbr.fit.interlockSim.objects.cells.DynamicInOut
 import cz.vutbr.fit.interlockSim.objects.cells.DynamicRailSemaphore
 import cz.vutbr.fit.interlockSim.objects.cells.DynamicRailSwitch
+import cz.vutbr.fit.interlockSim.sim.ShuntingLoop
 import kotlin.reflect.KClass
 
 /**
@@ -35,21 +36,19 @@ internal object ShuntingLoopNetworkValidator {
 	private const val LABEL_SWITCH = "RailSwitch"
 	private const val LABEL_SEMAPHORE = "RailSemaphore"
 
-	// Coordinates are ShuntingLoop's hardcoded vyhybna.xml lookups (see ShuntingLoop.init).
-	// They must exactly match that contract, so extracting them to named constants
-	// would only duplicate labels already present in the Required.label field.
-	@Suppress("MagicNumber")
+	// Coordinates are sourced from ShuntingLoop.Companion constants so there is
+	// exactly one authoritative list of the vyhybna network contract.
 	private val REQUIRED_CELLS: List<Required> = listOf(
-		Required(11, 8, DynamicInOut::class, LABEL_IN_OUT),
-		Required(30, 8, DynamicInOut::class, LABEL_IN_OUT),
-		Required(15, 8, DynamicRailSwitch::class, LABEL_SWITCH),
-		Required(26, 8, DynamicRailSwitch::class, LABEL_SWITCH),
-		Required(14, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
-		Required(16, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
-		Required(17, 9, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
-		Required(24, 9, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
-		Required(25, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
-		Required(27, 8, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_IN_A_X, ShuntingLoop.COORD_IN_A_Y, DynamicInOut::class, LABEL_IN_OUT),
+		Required(ShuntingLoop.COORD_IN_B_X, ShuntingLoop.COORD_IN_B_Y, DynamicInOut::class, LABEL_IN_OUT),
+		Required(ShuntingLoop.COORD_SW_A_X, ShuntingLoop.COORD_SW_A_Y, DynamicRailSwitch::class, LABEL_SWITCH),
+		Required(ShuntingLoop.COORD_SW_B_X, ShuntingLoop.COORD_SW_B_Y, DynamicRailSwitch::class, LABEL_SWITCH),
+		Required(ShuntingLoop.COORD_SEM_ZA_X, ShuntingLoop.COORD_SEM_ZA_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_SEM_DOA1_X, ShuntingLoop.COORD_SEM_DOA1_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_SEM_DOA2_X, ShuntingLoop.COORD_SEM_DOA2_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_SEM_DOB2_X, ShuntingLoop.COORD_SEM_DOB2_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_SEM_DOB1_X, ShuntingLoop.COORD_SEM_DOB1_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
+		Required(ShuntingLoop.COORD_SEM_ZB_X, ShuntingLoop.COORD_SEM_ZB_Y, DynamicRailSemaphore::class, LABEL_SEMAPHORE),
 	)
 
 	/**

--- a/fast-sim/src/linuxX64Test/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidatorTest.kt
+++ b/fast-sim/src/linuxX64Test/kotlin/cz/vutbr/fit/interlockSim/fastsim/ShuntingLoopNetworkValidatorTest.kt
@@ -1,0 +1,69 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator
+ *
+ * Bedrich Hovorka
+ */
+package cz.vutbr.fit.interlockSim.fastsim
+
+import cz.vutbr.fit.interlockSim.di.coreModule
+import cz.vutbr.fit.interlockSim.testutil.NetworkResources
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ShuntingLoopNetworkValidator] (Issue #435).
+ *
+ * Verifies that:
+ * - A vyhybna-compatible network produces an empty issue list.
+ * - A non-compatible network (e.g., LINEAR_TRACK_XML) produces actionable issues.
+ */
+class ShuntingLoopNetworkValidatorTest {
+
+	private val factory = NativeContextFactory()
+
+	@BeforeTest
+	fun setUp() {
+		startKoin { modules(coreModule) }
+	}
+
+	@AfterTest
+	fun tearDown() {
+		stopKoin()
+	}
+
+	@Test
+	fun `validateVyhybnaCompatible returns empty list for canonical vyhybna network`() {
+		val ctx = factory.createFromXml(NetworkResources.VYHYBNA_XML)
+		try {
+			val issues = ShuntingLoopNetworkValidator.validateVyhybnaCompatible(ctx)
+			assertEquals(emptyList(), issues, "vyhybna.xml must be vyhybna-compatible")
+		} finally {
+			ctx.close()
+		}
+	}
+
+	@Test
+	fun `validateVyhybnaCompatible reports actionable issues for linear track network`() {
+		val ctx = factory.createFromXml(NetworkResources.LINEAR_TRACK_XML)
+		try {
+			val issues = ShuntingLoopNetworkValidator.validateVyhybnaCompatible(ctx)
+			assertTrue(issues.isNotEmpty(), "LINEAR_TRACK_XML must not be vyhybna-compatible")
+			// Must include the specific coordinate that's missing (30, 8) — an InOut.
+			assertTrue(
+				issues.any { it.contains("(30, 8)") && it.contains("InOut") },
+				"expected issue mentioning missing InOut at (30, 8); got: $issues",
+			)
+		} finally {
+			ctx.close()
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements #435 at MVP level (option 1 of the three listed in the issue):
fast-sim now validates the loaded network before constructing
ShuntingLoop and exits with code 2 + an actionable message when required
InOut/switch/semaphore cells are missing. No registry, no auto-detect —
those are explicitly deferred to a future PR.

## Validation rules

Required cells (see ShuntingLoop.kt init block):
- InOut at (11,8), (30,8)
- Switch at (15,8), (26,8)
- Semaphores at (14,8) (16,8) (17,9) (24,9) (25,8) (27,8)

## Note on the included sim/ fix

The first commit `fix(sim): replace Map.merge with native-compatible increment`
is a minimal workaround for a native-only compile error introduced by PR
#454 (base branch). Kotlin/Native's `MutableMap` has no `merge(K, V, BiFunction)`.
The replacement `(existing ?: 0) + 1` is semantically identical. Without
it, `:core:compileKotlinLinuxX64` fails and the new native tests cannot run.
If #454 is fixed upstream first, this commit can be dropped in rebase.

## Test plan
- [x] validateVyhybnaCompatible unit tests (valid + missing-element)
- [x] :core:checkCoreCommonMainPurity
- [x] ktlintCheck + detekt
- [x] test + integrationTest
- [x] :fast-sim:build green (24 native tests, +2 new)
- [ ] CI green
- [ ] Human review of message wording

Base branch is feature/issue-365-shuntingloop-instrumentation (PR #454)
to keep the downstream chain visible; no code dependency on #365 — will
rebase onto develop after #454 merges.

Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
