### PR TITLE
feat(gui): add SimulationRunner with speed + pause control (#188)

### DIFF
--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
@@ -1,0 +1,207 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator
+ *
+ * Bedrich Hovorka
+ */
+package cz.vutbr.fit.interlockSim.gui
+
+import cz.vutbr.fit.interlockSim.context.SimulationContext
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.beans.PropertyChangeListener
+import java.beans.PropertyChangeSupport
+
+/**
+ * Wall-clock throttling wrapper around [SimulationContext.run].
+ *
+ * Phase 1.1 of Goal 7 (Issue #188). Provides speed control and pause support
+ * without altering simulation semantics. Speed only affects the rate at which
+ * simulation events are observed in wall-clock time; the event sequence,
+ * timestamps, and physics remain identical to an unthrottled run.
+ *
+ * Threading model:
+ *  - [start] launches a dedicated simulation thread that invokes [context.run].
+ *  - The kDisco dispatcher is single-threaded; Swing/EDT may read/write
+ *    [speedMultiplier] and [isPaused] concurrently with the simulation thread,
+ *    so both are `@Volatile`.
+ *  - [throttle] and [awaitIfPaused] are called from the simulation thread only.
+ *
+ * Not wired into Main/Frame by this change — that is Issue #189's scope.
+ *
+ * @see <a href="https://github.com/bedaHovorka/interlockSim/issues/188">Issue #188</a>
+ */
+class SimulationRunner(
+	private val context: SimulationContext
+) {
+	private val pcs = PropertyChangeSupport(this)
+	private val lifecycleLock = Any()
+	private val pauseLock = Object()
+
+	@Volatile
+	private var simThread: Thread? = null
+
+	@Volatile
+	private var speedMultiplierBacking: Double = DEFAULT_SPEED
+
+	@Volatile
+	private var pausedBacking: Boolean = false
+
+	/**
+	 * Wall-clock speed multiplier. 1.0 = real-time (simulation seconds
+	 * elapse in wall-clock seconds); 2.0 = twice as fast; 0.5 = half speed.
+	 *
+	 * Valid range: [MIN_SPEED]..[MAX_SPEED]. Values outside the range
+	 * throw [IllegalArgumentException].
+	 *
+	 * Fires a [PropertyChangeSupport] event with name [PROP_SPEED_MULTIPLIER]
+	 * on change.
+	 */
+	var speedMultiplier: Double
+		get() = speedMultiplierBacking
+		set(value) {
+			require(value in MIN_SPEED..MAX_SPEED) {
+				"speedMultiplier must be in [$MIN_SPEED..$MAX_SPEED], got: $value"
+			}
+			val old = speedMultiplierBacking
+			if (old != value) {
+				speedMultiplierBacking = value
+				pcs.firePropertyChange(PROP_SPEED_MULTIPLIER, old, value)
+			}
+		}
+
+	/**
+	 * Pause flag. When true, [awaitIfPaused] blocks the simulation thread
+	 * without advancing simulation time. When set back to false, any blocked
+	 * thread is released.
+	 *
+	 * Fires a [PropertyChangeSupport] event with name [PROP_IS_PAUSED]
+	 * on change.
+	 */
+	var isPaused: Boolean
+		get() = pausedBacking
+		set(value) {
+			val old: Boolean
+			synchronized(pauseLock) {
+				old = pausedBacking
+				if (old == value) return
+				pausedBacking = value
+				if (!value) {
+					pauseLock.notifyAll()
+				}
+			}
+			pcs.firePropertyChange(PROP_IS_PAUSED, old, value)
+		}
+
+	/** Register a listener for all property change events. */
+	fun addPropertyChangeListener(listener: PropertyChangeListener) {
+		pcs.addPropertyChangeListener(listener)
+	}
+
+	/** Register a listener for a specific property. */
+	fun addPropertyChangeListener(propertyName: String, listener: PropertyChangeListener) {
+		pcs.addPropertyChangeListener(propertyName, listener)
+	}
+
+	fun removePropertyChangeListener(listener: PropertyChangeListener) {
+		pcs.removePropertyChangeListener(listener)
+	}
+
+	fun removePropertyChangeListener(propertyName: String, listener: PropertyChangeListener) {
+		pcs.removePropertyChangeListener(propertyName, listener)
+	}
+
+	/**
+	 * Launch the simulation on a dedicated daemon thread. Idempotent: if a
+	 * simulation thread is already live, this call is a no-op.
+	 */
+	fun start() {
+		synchronized(lifecycleLock) {
+			val existing = simThread
+			if (existing != null && existing.isAlive) {
+				logger.debug { "start() ignored — simulation thread already alive" }
+				return
+			}
+			val thread = Thread({
+				try {
+					context.run()
+				} catch (e: InterruptedException) {
+					logger.debug { "Simulation thread interrupted: ${e.message}" }
+					Thread.currentThread().interrupt()
+				}
+			}, "SimulationRunner-sim")
+			thread.isDaemon = true
+			simThread = thread
+			thread.start()
+		}
+	}
+
+	/**
+	 * Request simulation shutdown. Interrupts the simulation thread and
+	 * wakes any paused wait. Safe to call when not started. Idempotent.
+	 */
+	fun stop() {
+		synchronized(lifecycleLock) {
+			val thread = simThread
+			// Release any paused wait so the thread can observe interrupt.
+			synchronized(pauseLock) {
+				pauseLock.notifyAll()
+			}
+			if (thread != null && thread.isAlive) {
+				thread.interrupt()
+			}
+			simThread = null
+		}
+	}
+
+	/** True if a simulation thread has been started and is still alive. */
+	fun isRunning(): Boolean = simThread?.isAlive == true
+
+	/**
+	 * Block the calling thread (expected to be the simulation thread) while
+	 * [isPaused] is true. Returns immediately when not paused. Respects
+	 * thread interruption.
+	 */
+	@Throws(InterruptedException::class)
+	fun awaitIfPaused() {
+		synchronized(pauseLock) {
+			while (pausedBacking) {
+				pauseLock.wait()
+			}
+		}
+	}
+
+	/**
+	 * Sleep wall-clock time proportional to the simulation delta scaled by
+	 * [speedMultiplier]. If paused, blocks until resumed before sleeping.
+	 *
+	 * @param simDeltaSeconds Simulation time advanced since the previous
+	 *     tick, in seconds. Must be non-negative. Zero or negative values
+	 *     are a no-op.
+	 */
+	@Throws(InterruptedException::class)
+	fun throttle(simDeltaSeconds: Double) {
+		awaitIfPaused()
+		if (simDeltaSeconds <= 0.0) return
+		val speed = speedMultiplierBacking
+		val sleepMs = (simDeltaSeconds / speed * MILLIS_PER_SECOND).toLong()
+		if (sleepMs > 0) {
+			Thread.sleep(sleepMs)
+		}
+	}
+
+	companion object {
+		const val MIN_SPEED: Double = 0.1
+		const val MAX_SPEED: Double = 100.0
+		const val DEFAULT_SPEED: Double = 1.0
+
+		const val PROP_SPEED_MULTIPLIER: String = "speedMultiplier"
+		const val PROP_IS_PAUSED: String = "isPaused"
+
+		private const val MILLIS_PER_SECOND: Double = 1000.0
+
+		private val logger = KotlinLogging.logger {}
+	}
+}

--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
@@ -124,14 +124,26 @@ class SimulationRunner(
 				logger.debug { "start() ignored — simulation thread already alive" }
 				return
 			}
-			val thread = Thread({
-				try {
-					context.run()
-				} catch (e: InterruptedException) {
-					logger.debug { "Simulation thread interrupted: ${e.message}" }
-					Thread.currentThread().interrupt()
-				}
-			}, "SimulationRunner-sim")
+			val thread = Thread(
+				@Suppress("TooGenericExceptionCaught")
+				{
+					try {
+						context.run()
+					} catch (e: InterruptedException) {
+						logger.debug { "Simulation thread interrupted: ${e.message}" }
+						Thread.currentThread().interrupt()
+					} catch (t: Throwable) {
+						logger.error(t) { "Simulation thread terminated unexpectedly" }
+					} finally {
+						synchronized(lifecycleLock) {
+							if (simThread === Thread.currentThread()) {
+								simThread = null
+							}
+						}
+					}
+				},
+				"SimulationRunner-sim"
+			)
 			thread.isDaemon = true
 			simThread = thread
 			thread.start()
@@ -143,17 +155,19 @@ class SimulationRunner(
 	 * wakes any paused wait. Safe to call when not started. Idempotent.
 	 */
 	fun stop() {
+		// Interrupt under lifecycleLock only; do NOT hold two locks at once.
 		synchronized(lifecycleLock) {
 			val thread = simThread
-			// Release any paused wait so the thread can observe interrupt.
-			synchronized(pauseLock) {
-				pauseLock.notifyAll()
-			}
 			if (thread != null && thread.isAlive) {
 				thread.interrupt()
 			}
-			simThread = null
 		}
+		// Wake any paused wait OUTSIDE lifecycleLock so we never hold both locks.
+		synchronized(pauseLock) {
+			pauseLock.notifyAll()
+		}
+		// simThread is cleared by the simulation thread's own finally block
+		// once it truly terminates.
 	}
 
 	/** True if a simulation thread has been started and is still alive. */
@@ -183,10 +197,10 @@ class SimulationRunner(
 	 */
 	@Throws(InterruptedException::class)
 	fun throttle(simDeltaSeconds: Double) {
-		awaitIfPaused()
 		if (simDeltaSeconds <= 0.0) return
+		awaitIfPaused()
 		val speed = speedMultiplierBacking
-		val sleepMs = (simDeltaSeconds / speed * MILLIS_PER_SECOND).toLong()
+		val sleepMs = Math.round(simDeltaSeconds / speed * MILLIS_PER_SECOND)
 		if (sleepMs > 0) {
 			Thread.sleep(sleepMs)
 		}

--- a/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
+++ b/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
@@ -1,0 +1,266 @@
+/*
+	Brno University of Technology
+	Faculty of Information Technology
+
+	BSc Thesis       2006/2007
+	Railway Interlocking Simulator
+
+	Unit tests for SimulationRunner (Issue #188)
+*/
+
+package cz.vutbr.fit.interlockSim.gui
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import cz.vutbr.fit.interlockSim.context.SimulationContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.beans.PropertyChangeEvent
+import java.beans.PropertyChangeListener
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@DisplayName("SimulationRunner")
+class SimulationRunnerTest {
+	private lateinit var context: SimulationContext
+	private lateinit var runner: SimulationRunner
+
+	@BeforeEach
+	fun setUp() {
+		context = mockk(relaxed = true)
+		runner = SimulationRunner(context)
+	}
+
+	@Test
+	@DisplayName("defaults: speedMultiplier=1.0, isPaused=false, not running")
+	fun defaults() {
+		assertThat(runner.speedMultiplier).isEqualTo(1.0)
+		assertThat(runner.isPaused).isFalse()
+		assertThat(runner.isRunning()).isFalse()
+	}
+
+	@Test
+	@DisplayName("speed 0.09 below lower bound throws")
+	fun speedBelowLowerBoundThrows() {
+		assertThrows(IllegalArgumentException::class.java) { runner.speedMultiplier = 0.09 }
+	}
+
+	@Test
+	@DisplayName("speed 0.1 accepted (inclusive lower bound)")
+	fun speedLowerBoundAccepted() {
+		runner.speedMultiplier = 0.1
+		assertThat(runner.speedMultiplier).isEqualTo(0.1)
+	}
+
+	@Test
+	@DisplayName("speed 1.0 accepted")
+	fun speedOneAccepted() {
+		runner.speedMultiplier = 1.0
+		assertThat(runner.speedMultiplier).isEqualTo(1.0)
+	}
+
+	@Test
+	@DisplayName("speed 100.0 accepted (inclusive upper bound)")
+	fun speedUpperBoundAccepted() {
+		runner.speedMultiplier = 100.0
+		assertThat(runner.speedMultiplier).isEqualTo(100.0)
+	}
+
+	@Test
+	@DisplayName("speed 100.1 above upper bound throws")
+	fun speedAboveUpperBoundThrows() {
+		assertThrows(IllegalArgumentException::class.java) { runner.speedMultiplier = 100.1 }
+	}
+
+	@Test
+	@DisplayName("PropertyChangeListener fires on speedMultiplier change with old/new values")
+	fun speedChangeFiresListener() {
+		val events = mutableListOf<PropertyChangeEvent>()
+		runner.addPropertyChangeListener(SimulationRunner.PROP_SPEED_MULTIPLIER, PropertyChangeListener { events.add(it) })
+
+		runner.speedMultiplier = 2.5
+
+		assertThat(events.size).isEqualTo(1)
+		val evt = events[0]
+		assertThat(evt.propertyName).isEqualTo(SimulationRunner.PROP_SPEED_MULTIPLIER)
+		assertThat(evt.oldValue as Double).isEqualTo(1.0)
+		assertThat(evt.newValue as Double).isEqualTo(2.5)
+	}
+
+	@Test
+	@DisplayName("speed listener not fired when value unchanged")
+	fun speedUnchangedDoesNotFire() {
+		val events = mutableListOf<PropertyChangeEvent>()
+		runner.addPropertyChangeListener(PropertyChangeListener { events.add(it) })
+
+		runner.speedMultiplier = 1.0 // same as default
+
+		assertThat(events.size).isEqualTo(0)
+	}
+
+	@Test
+	@DisplayName("PropertyChangeListener fires on isPaused change")
+	fun pausedChangeFiresListener() {
+		val events = mutableListOf<PropertyChangeEvent>()
+		runner.addPropertyChangeListener(SimulationRunner.PROP_IS_PAUSED, PropertyChangeListener { events.add(it) })
+
+		runner.isPaused = true
+
+		assertThat(events.size).isEqualTo(1)
+		assertThat(events[0].oldValue as Boolean).isFalse()
+		assertThat(events[0].newValue as Boolean).isTrue()
+	}
+
+	@Test
+	@DisplayName("isPaused unchanged does not fire")
+	fun pausedUnchangedDoesNotFire() {
+		val events = mutableListOf<PropertyChangeEvent>()
+		runner.addPropertyChangeListener(PropertyChangeListener { events.add(it) })
+
+		runner.isPaused = false // same as default
+
+		assertThat(events.size).isEqualTo(0)
+	}
+
+	@Test
+	@DisplayName("removePropertyChangeListener stops notifications")
+	fun removeListener() {
+		val events = mutableListOf<PropertyChangeEvent>()
+		val listener = PropertyChangeListener { events.add(it) }
+		runner.addPropertyChangeListener(listener)
+		runner.speedMultiplier = 2.0
+		runner.removePropertyChangeListener(listener)
+		runner.speedMultiplier = 3.0
+
+		assertThat(events.size).isEqualTo(1)
+	}
+
+	@Test
+	@DisplayName("start invokes context.run on background thread")
+	fun startInvokesContextRun() {
+		val started = CountDownLatch(1)
+		val finish = CountDownLatch(1)
+		every { context.run() } answers {
+			started.countDown()
+			finish.await(5, TimeUnit.SECONDS)
+		}
+
+		runner.start()
+		assertThat(started.await(5, TimeUnit.SECONDS)).isTrue()
+		assertThat(runner.isRunning()).isTrue()
+
+		finish.countDown()
+		runner.stop()
+		verify { context.run() }
+	}
+
+	@Test
+	@DisplayName("start is idempotent while thread alive")
+	fun startIdempotent() {
+		val started = CountDownLatch(1)
+		val finish = CountDownLatch(1)
+		every { context.run() } answers {
+			started.countDown()
+			finish.await(5, TimeUnit.SECONDS)
+		}
+
+		runner.start()
+		started.await(5, TimeUnit.SECONDS)
+		runner.start() // second call — should not invoke context.run again
+		runner.start()
+
+		finish.countDown()
+		runner.stop()
+		verify(exactly = 1) { context.run() }
+	}
+
+	@Test
+	@DisplayName("stop on never-started runner is safe")
+	fun stopIdempotentOnUnstarted() {
+		runner.stop() // no exception
+		runner.stop()
+		assertThat(runner.isRunning()).isFalse()
+	}
+
+	@Test
+	@DisplayName("stop interrupts sim thread and terminates it")
+	fun stopInterruptsSimThread() {
+		val started = CountDownLatch(1)
+		val interrupted = CountDownLatch(1)
+		every { context.run() } answers {
+			started.countDown()
+			try {
+				Thread.sleep(60_000)
+			} catch (e: InterruptedException) {
+				interrupted.countDown()
+				Thread.currentThread().interrupt()
+			}
+		}
+
+		runner.start()
+		started.await(5, TimeUnit.SECONDS)
+		runner.stop()
+
+		assertThat(interrupted.await(5, TimeUnit.SECONDS)).isTrue()
+	}
+
+	@Test
+	@DisplayName("awaitIfPaused blocks while paused and resumes on unpause")
+	fun pauseThenResume() {
+		runner.isPaused = true
+
+		val resumed = CountDownLatch(1)
+		val waiter = Thread {
+			try {
+				runner.awaitIfPaused()
+				resumed.countDown()
+			} catch (_: InterruptedException) {
+				// ignored
+			}
+		}
+		waiter.isDaemon = true
+		waiter.start()
+
+		// Give the waiter time to enter the wait
+		Thread.sleep(100)
+		assertThat(resumed.count).isEqualTo(1L)
+
+		runner.isPaused = false
+		assertThat(resumed.await(5, TimeUnit.SECONDS)).isTrue()
+		waiter.join(1000)
+	}
+
+	@Test
+	@DisplayName("awaitIfPaused is a no-op when not paused")
+	fun awaitIfPausedNoop() {
+		// should return promptly
+		runner.awaitIfPaused()
+	}
+
+	@Test
+	@DisplayName("throttle with non-positive delta is a no-op")
+	fun throttleNonPositive() {
+		runner.throttle(0.0)
+		runner.throttle(-1.0)
+		// no sleep, no exception
+	}
+
+	@Test
+	@DisplayName("throttle sleeps roughly simDelta / speed seconds")
+	fun throttleSleeps() {
+		runner.speedMultiplier = 10.0 // 100ms for 1.0s delta
+		val startNs = System.nanoTime()
+		runner.throttle(1.0)
+		val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+		// Allow generous timing slack; must have slept at least ~80ms, at most ~500ms
+		assertThat(elapsedMs >= 80).isTrue()
+		assertThat(elapsedMs < 500).isTrue()
+	}
+}

--- a/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
+++ b/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
@@ -216,9 +216,14 @@ class SimulationRunnerTest {
 	fun pauseThenResume() {
 		runner.isPaused = true
 
+		val reachedWait = CountDownLatch(1)
 		val resumed = CountDownLatch(1)
 		val waiter = Thread {
 			try {
+				// Signals the waiter is about to call awaitIfPaused().
+				// Combined with isPaused=true being set first, this is a
+				// tight-enough handshake to avoid Thread.sleep-based timing.
+				reachedWait.countDown()
 				runner.awaitIfPaused()
 				resumed.countDown()
 			} catch (_: InterruptedException) {
@@ -228,28 +233,46 @@ class SimulationRunnerTest {
 		waiter.isDaemon = true
 		waiter.start()
 
-		// Give the waiter time to enter the wait
-		Thread.sleep(100)
+		// Ensure the waiter thread reached the handshake.
+		assertThat(reachedWait.await(5, TimeUnit.SECONDS)).isTrue()
+		// resumed must still be blocked while paused.
 		assertThat(resumed.count).isEqualTo(1L)
 
 		runner.isPaused = false
 		assertThat(resumed.await(5, TimeUnit.SECONDS)).isTrue()
-		waiter.join(1000)
+		waiter.join(5000)
+		assertThat(waiter.isAlive).isFalse()
 	}
 
 	@Test
 	@DisplayName("awaitIfPaused is a no-op when not paused")
 	fun awaitIfPausedNoop() {
-		// should return promptly
+		val startNs = System.nanoTime()
 		runner.awaitIfPaused()
+		val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+		assertThat(elapsedMs < 50L).isTrue()
 	}
 
 	@Test
 	@DisplayName("throttle with non-positive delta is a no-op")
 	fun throttleNonPositive() {
+		val startNs = System.nanoTime()
 		runner.throttle(0.0)
 		runner.throttle(-1.0)
-		// no sleep, no exception
+		val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+		assertThat(elapsedMs < 50L).isTrue()
+	}
+
+	@Test
+	@DisplayName("throttle with non-positive delta is a no-op even when paused")
+	fun throttleNonPositiveWhenPaused() {
+		// P1 fix: non-positive delta must early-return BEFORE awaitIfPaused().
+		runner.isPaused = true
+		val startNs = System.nanoTime()
+		runner.throttle(0.0)
+		runner.throttle(-1.0)
+		val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+		assertThat(elapsedMs < 50L).isTrue()
 	}
 
 	@Test
@@ -259,8 +282,9 @@ class SimulationRunnerTest {
 		val startNs = System.nanoTime()
 		runner.throttle(1.0)
 		val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
-		// Allow generous timing slack; must have slept at least ~80ms, at most ~500ms
+		// Must have slept at least ~80ms. Upper bound kept loose (<2000ms)
+		// to avoid flakes on busy CI while still catching pathological hangs.
 		assertThat(elapsedMs >= 80).isTrue()
-		assertThat(elapsedMs < 500).isTrue()
+		assertThat(elapsedMs < 2000).isTrue()
 	}
 }


### PR DESCRIPTION
## Summary

Implements #188 (Phase 1.1 of Goal 7: Simulation Speed Control).

Introduces `SimulationRunner` — a wall-clock throttling wrapper around
`SimulationContext.run()` with speed control (0.1x-100x) and pause
support. Simulation semantics are unchanged; only the observation rate
varies.

## API

- `speedMultiplier: Double` (0.1..100.0, default 1.0, PCS-observable)
- `isPaused: Boolean` (default false, PCS-observable)
- `start()` / `stop()` coordinating with `context.run()`
- `awaitIfPaused()` and `throttle(simDeltaSeconds)` helpers for the
  simulation thread (to be consumed by #189 wiring)

## Not in this PR

- GUI wiring (Main/Frame integration) — #189
- Golden-invariance testing — #195
- Performance benchmarks — #196
- Integration/regression tests — #197/#198

## Test plan
- [x] checkCoreCommonMainPurity
- [x] ktlintCheck + detekt
- [x] test (unit) — 19 new tests, full suite green
- [x] integrationTest — all passing
- [ ] CI green on Gradle Java 21
- [ ] Human review of API shape and threading

Closes #188. Unblocks #189, #195, #196, #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)