### PR TITLE
test: expand coverage in context / navigation / paths / exceptions (#453)

### DIFF
--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextExceptionsTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/ContextExceptionsTest.kt
@@ -1,0 +1,87 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator - Test Suite
+ *
+ * Unit tests for EmptyContextException and ContextCreationException constructor overloads.
+ * Added for Issue #453 to cover all 4 ctor variants of each.
+ */
+package cz.vutbr.fit.interlockSim.context
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Context exception constructors (Issue #453)")
+class ContextExceptionsTest {
+	private val testMessage = "context test failure"
+	private val testCause = RuntimeException("root cause")
+
+	@Test
+	fun `EmptyContextException no-arg constructor`() {
+		val e = EmptyContextException()
+		assertThat(e).isInstanceOf(Exception::class)
+		assertThat(e.message).isEqualTo(null)
+		assertThat(e.cause).isEqualTo(null)
+	}
+
+	@Test
+	fun `EmptyContextException message-only constructor`() {
+		val e = EmptyContextException(testMessage)
+		assertThat(e.message).isEqualTo(testMessage)
+		assertThat(e.cause).isEqualTo(null)
+	}
+
+	@Test
+	fun `EmptyContextException cause-only constructor`() {
+		val e = EmptyContextException(testCause)
+		assertThat(e.cause).isEqualTo(testCause)
+	}
+
+	@Test
+	fun `EmptyContextException message+cause constructor`() {
+		val e = EmptyContextException(testMessage, testCause)
+		assertThat(e.message).isEqualTo(testMessage)
+		assertThat(e.cause).isEqualTo(testCause)
+	}
+
+	@Test
+	fun `ContextCreationException no-arg constructor`() {
+		val e = ContextCreationException()
+		assertThat(e).isInstanceOf(Exception::class)
+		assertThat(e.cause).isEqualTo(null)
+	}
+
+	@Test
+	fun `ContextCreationException cause-only constructor`() {
+		val e = ContextCreationException(testCause)
+		assertThat(e.cause).isEqualTo(testCause)
+	}
+
+	@Test
+	fun `ContextCreationException string-only constructor`() {
+		val e = ContextCreationException(testMessage)
+		assertThat(e.message).isEqualTo(testMessage)
+		assertThat(e.cause).isEqualTo(null)
+	}
+
+	@Test
+	fun `ContextCreationException message+cause constructor preserves both`() {
+		val e = ContextCreationException(testMessage, testCause)
+		assertThat(e).isNotNull()
+		assertThat(e.message).isEqualTo(testMessage)
+		assertThat(e.cause).isEqualTo(testCause)
+	}
+
+	@Test
+	fun `ContextCreationException message+null cause is allowed`() {
+		val e = ContextCreationException(testMessage, null)
+		assertThat(e.message).isEqualTo(testMessage)
+		assertThat(e.cause).isEqualTo(null)
+	}
+}

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/ReservationResultTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/ReservationResultTest.kt
@@ -1,0 +1,115 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator - Test Suite
+ *
+ * Coverage test for PathReservationService.ReservationResult sealed hierarchy (Issue #453).
+ */
+package cz.vutbr.fit.interlockSim.context.navigation
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isSameInstanceAs
+import cz.vutbr.fit.interlockSim.context.DefaultSimulationContext
+import cz.vutbr.fit.interlockSim.context.EditingContext
+import cz.vutbr.fit.interlockSim.context.EditingContextFactory
+import cz.vutbr.fit.interlockSim.context.SimulationContextFactory
+import cz.vutbr.fit.interlockSim.objects.tracks.DynamicTrackBlock
+import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
+import cz.vutbr.fit.interlockSim.testutil.TestFixtures
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.koin.test.inject
+import java.io.InputStream
+
+/**
+ * Smoke tests for [PathReservationService.ReservationResult] subtypes that are
+ * instantiable but were not exercised by existing tests (NoPathExists, Conflict).
+ */
+@DisplayName("PathReservationService.ReservationResult (Issue #453)")
+class ReservationResultTest : KoinTestBase() {
+	private val editingContextFactory: EditingContextFactory by inject()
+	private val simulationContextFactory: SimulationContextFactory by inject()
+
+	private lateinit var blocks: List<DynamicTrackBlock>
+
+	@BeforeEach
+	fun setUp() {
+		val xmlStream: InputStream =
+			TestFixtures.loadShuntingXml()
+				?: throw IllegalStateException("vyhybna.xml not found in resources")
+		val editing = editingContextFactory.createContext(xmlStream) as EditingContext
+		val simCtx = simulationContextFactory.createContext(editing) as DefaultSimulationContext
+		val inOuts = simCtx.getInOuts().toList()
+		val navigator: TopologyNavigator = simCtx.scope.get()
+		blocks =
+			navigator
+				.findAllTopologicalPaths(inOuts[0], inOuts[1])
+				.first()
+				.mapNotNull { section ->
+					val block = section.getTrackBlock()
+					if (block is DynamicTrackBlock) block else null
+				}.distinct()
+	}
+
+	@Test
+	fun `NoPathExists is a singleton data object`() {
+		val first: PathReservationService.ReservationResult = PathReservationService.ReservationResult.NoPathExists
+		val second: PathReservationService.ReservationResult = PathReservationService.ReservationResult.NoPathExists
+
+		assertThat(first).isSameInstanceAs(second)
+		assertThat(first).isInstanceOf<PathReservationService.ReservationResult.NoPathExists>()
+	}
+
+	@Test
+	fun `Conflict carries conflicting block and existing owner`() {
+		val block = blocks.first()
+		val conflict = PathReservationService.ReservationResult.Conflict(block, "T1")
+
+		assertThat(conflict.conflictingBlock).isSameInstanceAs(block)
+		assertThat(conflict.existingOwner).isEqualTo("T1")
+		assertThat(conflict).isInstanceOf<PathReservationService.ReservationResult.Conflict>()
+	}
+
+	@Test
+	fun `Conflict data class equality and hashCode`() {
+		val block = blocks.first()
+		val a = PathReservationService.ReservationResult.Conflict(block, "T1")
+		val b = PathReservationService.ReservationResult.Conflict(block, "T1")
+		val c = PathReservationService.ReservationResult.Conflict(block, "T2")
+
+		assertThat(a).isEqualTo(b)
+		assertThat(a.hashCode()).isEqualTo(b.hashCode())
+		assertThat(a).isNotEqualTo(c)
+		// Exercise copy() + componentN of data class
+		val copied = a.copy(existingOwner = "T3")
+		assertThat(copied.existingOwner).isEqualTo("T3")
+		assertThat(copied.conflictingBlock).isSameInstanceAs(block)
+	}
+
+	@Test
+	fun `AllPathsBlocked carries attempted count and supports equality`() {
+		val a = PathReservationService.ReservationResult.AllPathsBlocked(3)
+		val b = PathReservationService.ReservationResult.AllPathsBlocked(3)
+		val c = PathReservationService.ReservationResult.AllPathsBlocked(5)
+
+		assertThat(a).isEqualTo(b)
+		assertThat(a).isNotEqualTo(c)
+		assertThat(a.attemptedPaths).isEqualTo(3)
+	}
+
+	@Test
+	fun `Success data class equality and reservedBlocks accessor`() {
+		val sample = blocks.take(2)
+		val s1 = PathReservationService.ReservationResult.Success(sample)
+		val s2 = PathReservationService.ReservationResult.Success(sample)
+
+		assertThat(s1).isEqualTo(s2)
+		assertThat(s1.reservedBlocks).isEqualTo(sample)
+	}
+}

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/ReservationResultTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/context/navigation/ReservationResultTest.kt
@@ -21,10 +21,13 @@ import cz.vutbr.fit.interlockSim.context.SimulationContextFactory
 import cz.vutbr.fit.interlockSim.objects.tracks.DynamicTrackBlock
 import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
 import cz.vutbr.fit.interlockSim.testutil.TestFixtures
-import org.junit.jupiter.api.BeforeEach
+import cz.vutbr.fit.interlockSim.testutil.coreTestModule
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.koin.test.inject
+import org.junit.jupiter.api.TestInstance
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import java.io.InputStream
 
 /**
@@ -32,29 +35,40 @@ import java.io.InputStream
  * instantiable but were not exercised by existing tests (NoPathExists, Conflict).
  */
 @DisplayName("PathReservationService.ReservationResult (Issue #453)")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ReservationResultTest : KoinTestBase() {
-	private val editingContextFactory: EditingContextFactory by inject()
-	private val simulationContextFactory: SimulationContextFactory by inject()
-
 	private lateinit var blocks: List<DynamicTrackBlock>
 
-	@BeforeEach
-	fun setUp() {
-		val xmlStream: InputStream =
-			TestFixtures.loadShuntingXml()
-				?: throw IllegalStateException("vyhybna.xml not found in resources")
-		val editing = editingContextFactory.createContext(xmlStream) as EditingContext
-		val simCtx = simulationContextFactory.createContext(editing) as DefaultSimulationContext
-		val inOuts = simCtx.getInOuts().toList()
-		val navigator: TopologyNavigator = simCtx.scope.get()
-		blocks =
-			navigator
-				.findAllTopologicalPaths(inOuts[0], inOuts[1])
-				.first()
-				.mapNotNull { section ->
-					val block = section.getTrackBlock()
-					if (block is DynamicTrackBlock) block else null
-				}.distinct()
+	@BeforeAll
+	fun initFixture() {
+		// Build the shared fixture once per class. KoinTestBase runs its own
+		// @BeforeEach/@AfterEach start/stop cycle per test, so here we bring up
+		// Koin briefly, materialize the fixture data, then tear it down again
+		// so the per-test lifecycle remains unchanged.
+		val koinApp = startKoin { modules(coreTestModule) }
+		try {
+			val editingContextFactory = koinApp.koin.get<EditingContextFactory>()
+			val simulationContextFactory = koinApp.koin.get<SimulationContextFactory>()
+			val xmlStream: InputStream =
+				TestFixtures.loadShuntingXml()
+					?: throw IllegalStateException("vyhybna.xml not found in resources")
+			val editing = editingContextFactory.createContext(xmlStream) as EditingContext
+			val simCtx = simulationContextFactory.createContext(editing) as DefaultSimulationContext
+			val inOuts = simCtx.getInOuts().toList()
+			check(inOuts.size >= 2) { "fixture expected ≥2 InOuts; got ${inOuts.size}" }
+			val navigator: TopologyNavigator = simCtx.scope.get()
+			val paths = navigator.findAllTopologicalPaths(inOuts[0], inOuts[1])
+			check(paths.isNotEmpty()) { "fixture expected ≥1 topological path between inOuts[0] and inOuts[1]" }
+			blocks =
+				paths
+					.first()
+					.mapNotNull { section ->
+						val block = section.getTrackBlock()
+						if (block is DynamicTrackBlock) block else null
+					}.distinct()
+		} finally {
+			stopKoin()
+		}
 	}
 
 	@Test

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/EditorExceptionTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/EditorExceptionTest.kt
@@ -1,0 +1,216 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator - Test Suite
+ *
+ * Unit tests for EditorException (Issue #453)
+ * Relocated/duplicated into :core so JaCoCo :core attributes coverage.
+ */
+package cz.vutbr.fit.interlockSim.exceptions
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Unit tests for EditorException — covers all constructor overloads, Severity propagation,
+ * toString formatting, cause chain preservation, object storage, and hierarchy checks.
+ */
+@DisplayName("EditorException")
+class EditorExceptionTest {
+	private val testMessage = "Test editor exception message"
+	private val testCause = RuntimeException("Root cause")
+	private val testObj = Any()
+
+	@Nested
+	@DisplayName("Constructors")
+	inner class ConstructorTests {
+		@Test
+		fun `no-arg constructor creates exception with FATAL severity`() {
+			val exception = EditorException()
+			assertThat(exception).isNotNull()
+			assertThat(exception.severity).isEqualTo(Severity.FATAL)
+			assertThat(exception.message).isEqualTo("")
+			assertThat(exception.cause).isEqualTo(null)
+			assertThat(exception.getObject()).isEqualTo(null)
+		}
+
+		@Test
+		fun `constructor with object creates exception with FATAL severity`() {
+			val exception = EditorException(testObj)
+			assertThat(exception.severity).isEqualTo(Severity.FATAL)
+			assertThat(exception.message).isEqualTo("")
+			assertThat(exception.cause).isEqualTo(null)
+			assertThat(exception.getObject()).isEqualTo(testObj)
+		}
+
+		@Test
+		fun `constructor with message creates exception with FATAL severity`() {
+			val exception = EditorException(testMessage)
+			assertThat(exception.severity).isEqualTo(Severity.FATAL)
+			assertThat(exception.message).isEqualTo(testMessage)
+			assertThat(exception.cause).isEqualTo(null)
+			assertThat(exception.getObject()).isEqualTo(null)
+		}
+
+		@Test
+		fun `constructor with severity and message creates exception`() {
+			val exception = EditorException(Severity.ERROR, testMessage)
+			assertThat(exception.severity).isEqualTo(Severity.ERROR)
+			assertThat(exception.message).isEqualTo(testMessage)
+			assertThat(exception.cause).isEqualTo(null)
+			assertThat(exception.getObject()).isEqualTo(null)
+		}
+
+		@Test
+		fun `constructor with severity, message, and object creates exception`() {
+			val exception = EditorException(Severity.WARN, testMessage, testObj)
+			assertThat(exception.severity).isEqualTo(Severity.WARN)
+			assertThat(exception.message).isEqualTo(testMessage)
+			assertThat(exception.cause).isEqualTo(null)
+			assertThat(exception.getObject()).isEqualTo(testObj)
+		}
+
+		@Test
+		fun `constructor with cause creates exception with FATAL severity`() {
+			val exception = EditorException(testCause)
+			assertThat(exception.severity).isEqualTo(Severity.FATAL)
+			assertThat(exception.message).isEqualTo("")
+			assertThat(exception.cause).isEqualTo(testCause)
+			assertThat(exception.getObject()).isEqualTo(null)
+		}
+
+		@Test
+		fun `constructor with severity, cause, and object creates exception`() {
+			val exception = EditorException(Severity.ERROR, testCause, testObj)
+			assertThat(exception.severity).isEqualTo(Severity.ERROR)
+			assertThat(exception.message).isEqualTo("")
+			assertThat(exception.cause).isEqualTo(testCause)
+			assertThat(exception.getObject()).isEqualTo(testObj)
+		}
+
+		@Test
+		fun `primary constructor with all parameters creates exception`() {
+			val exception = EditorException(Severity.WARN, testMessage, testCause, testObj)
+			assertThat(exception.severity).isEqualTo(Severity.WARN)
+			assertThat(exception.message).isEqualTo(testMessage)
+			assertThat(exception.cause).isEqualTo(testCause)
+			assertThat(exception.getObject()).isEqualTo(testObj)
+		}
+	}
+
+	@Nested
+	@DisplayName("Severity Preservation")
+	inner class SeverityTests {
+		@ParameterizedTest(name = "{0} severity is preserved")
+		@EnumSource(Severity::class, names = ["FATAL", "ERROR", "WARN"])
+		fun `severity is preserved`(severity: Severity) {
+			val exception = EditorException(severity, testMessage)
+			assertThat(exception.severity).isEqualTo(severity)
+		}
+
+		@Test
+		fun `default severity is FATAL`() {
+			assertThat(EditorException().severity).isEqualTo(Severity.FATAL)
+			assertThat(EditorException(testMessage).severity).isEqualTo(Severity.FATAL)
+			assertThat(EditorException(testCause).severity).isEqualTo(Severity.FATAL)
+		}
+
+		@ParameterizedTest(name = "{0} in toString")
+		@EnumSource(Severity::class, names = ["FATAL", "ERROR", "WARN"])
+		fun `severity propagates in toString`(severity: Severity) {
+			val exception = EditorException(severity, testMessage)
+			assertThat(exception.toString()).contains(severity.name)
+		}
+	}
+
+	@Nested
+	@DisplayName("Message Formatting")
+	inner class MessageFormattingTests {
+		@Test
+		fun `toString includes class name`() {
+			val exception = EditorException(testMessage)
+			assertThat(exception.toString()).contains("EditorException")
+		}
+
+		@Test
+		fun `toString format is correct`() {
+			val exception = EditorException(Severity.WARN, testMessage)
+			val result = exception.toString()
+			assertThat(result).contains("EditorException[WARN]:")
+			assertThat(result).contains(testMessage)
+		}
+
+		@Test
+		fun `toString handles empty message`() {
+			val exception = EditorException()
+			assertThat(exception.toString()).contains("EditorException[FATAL]:")
+		}
+
+		@Test
+		fun `toString handles message with special characters`() {
+			val specialMessage = "Error: [test] with {brackets} and \"quotes\""
+			val exception = EditorException(specialMessage)
+			val result = exception.toString()
+			assertThat(result).contains("[test]")
+			assertThat(result).contains("{brackets}")
+			assertThat(result).contains("\"quotes\"")
+		}
+	}
+
+	@Nested
+	@DisplayName("Cause Chain Preservation")
+	inner class CauseChainTests {
+		@Test
+		fun `nested exception chain is preserved`() {
+			val deepCause = Exception("Deep cause")
+			val middleCause = Exception("Middle cause", deepCause)
+			val exception = EditorException(middleCause)
+			assertThat(exception.cause).isEqualTo(middleCause)
+			assertThat(exception.cause?.cause).isEqualTo(deepCause)
+		}
+
+		@Test
+		fun `stack trace is preserved`() {
+			val exception = EditorException(testMessage)
+			assertThat(exception.stackTrace).isNotNull()
+		}
+	}
+
+	@Nested
+	@DisplayName("getObject and hierarchy")
+	inner class ObjectAndHierarchyTests {
+		@Test
+		fun `getObject preserves object type`() {
+			data class TestData(val value: Int)
+			val data = TestData(42)
+			val exception = EditorException(Severity.ERROR, testMessage, data)
+			val result = exception.getObject()
+			assertThat(result).isNotNull()
+			assertThat(result as Any).isInstanceOf<TestData>()
+			assertThat((result as TestData).value).isEqualTo(42)
+		}
+
+		@Test
+		fun `EditorException is Exception`() {
+			val exception = EditorException(testMessage)
+			assertThat(exception).isInstanceOf(Exception::class)
+		}
+
+		@Test
+		fun `EditorException is throwable`() {
+			val exception = EditorException(testMessage)
+			assertFailure { throw exception }.isInstanceOf<EditorException>()
+		}
+	}
+}

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/EditorExceptionTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/EditorExceptionTest.kt
@@ -183,7 +183,7 @@ class EditorExceptionTest {
 		@Test
 		fun `stack trace is preserved`() {
 			val exception = EditorException(testMessage)
-			assertThat(exception.stackTrace).isNotNull()
+			assertThat(exception.stackTrace.isNotEmpty()).isEqualTo(true)
 		}
 	}
 
@@ -196,9 +196,9 @@ class EditorExceptionTest {
 			val data = TestData(42)
 			val exception = EditorException(Severity.ERROR, testMessage, data)
 			val result = exception.getObject()
-			assertThat(result).isNotNull()
-			assertThat(result as Any).isInstanceOf<TestData>()
-			assertThat((result as TestData).value).isEqualTo(42)
+			assertThat(result).isNotNull().isInstanceOf<TestData>()
+			val testData = result as TestData
+			assertThat(testData.value).isEqualTo(42)
 		}
 
 		@Test

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/RequireFunctionsTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/exceptions/RequireFunctionsTest.kt
@@ -1,0 +1,373 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator - Test Suite
+ *
+ * Unit tests for RequireFunctions utility functions (Issue #453)
+ * Relocated to :core so inline-function coverage is attributed to :core JaCoCo.
+ */
+package cz.vutbr.fit.interlockSim.exceptions
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import cz.vutbr.fit.interlockSim.testutil.hasMessageContaining
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/**
+ * Unit tests for RequireFunctions utility validation functions.
+ *
+ * Covers requireSimulation/requireEditor/requireValidArgument/requireValidState
+ * across positive, negative, lazy-message, and severity variants.
+ */
+@DisplayName("RequireFunctions")
+class RequireFunctionsTest {
+	@Nested
+	@DisplayName("requireSimulation")
+	inner class RequireSimulationTests {
+		@Test
+		fun `passes when condition is true`() {
+			requireSimulation(true) { "Should not be thrown" }
+		}
+
+		@Test
+		fun `throws SimulationException when false`() {
+			assertFailure {
+				requireSimulation(false) { "Test failure message" }
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Test failure message")
+		}
+
+		@Test
+		fun `uses default message when not provided`() {
+			assertFailure {
+				requireSimulation(false)
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Simulation requirement failed")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireSimulation(true, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+
+		@Test
+		fun `evaluates message when condition fails`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message evaluated"
+			}
+			assertFailure {
+				requireSimulation(false, lazyMessage)
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Lazy message evaluated")
+			assertThat(messageEvaluated).isEqualTo(true)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireSimulation with Severity")
+	inner class RequireSimulationSeverityTests {
+		@Test
+		fun `passes when condition is true with severity`() {
+			requireSimulation(true, Severity.ERROR) { "Should not be thrown" }
+		}
+
+		@ParameterizedTest(name = "severity {0}")
+		@EnumSource(Severity::class, names = ["FATAL", "ERROR", "WARN"])
+		fun `throws SimulationException with correct severity`(severity: Severity) {
+			assertFailure {
+				requireSimulation(false, severity) { "$severity message" }
+			}.isInstanceOf<SimulationException>().all {
+				hasMessage("$severity message")
+				prop(SimulationException::severity).isEqualTo(severity)
+			}
+		}
+
+		@Test
+		fun `uses default message with severity when not provided`() {
+			assertFailure {
+				requireSimulation(false, Severity.ERROR)
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Simulation requirement failed")
+		}
+	}
+
+	@Nested
+	@DisplayName("requireSimulationNotNull")
+	inner class RequireSimulationNotNullTests {
+		@Test
+		fun `returns value when not null`() {
+			val value = "test value"
+			val result = requireSimulationNotNull(value) { "Should not be thrown" }
+			assertThat(result).isEqualTo(value)
+		}
+
+		@Test
+		fun `throws SimulationException when null`() {
+			assertFailure {
+				requireSimulationNotNull(null) { "Value was null" }
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Value was null")
+		}
+
+		@Test
+		fun `uses default message when null and no message provided`() {
+			assertFailure {
+				requireSimulationNotNull(null)
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Required value was null")
+		}
+
+		@Test
+		fun `works with different types`() {
+			val intValue: Int? = 42
+			val stringValue: String? = "test"
+			val objectValue: Any? = Any()
+			assertThat(requireSimulationNotNull(intValue)).isEqualTo(42)
+			assertThat(requireSimulationNotNull(stringValue)).isEqualTo("test")
+			assertThat(requireSimulationNotNull(objectValue)).isNotNull()
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val value = "not null"
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireSimulationNotNull(value, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireSimulationState")
+	inner class RequireSimulationStateTests {
+		@Test
+		fun `passes when state is valid`() {
+			requireSimulationState(true) { "Should not be thrown" }
+		}
+
+		@Test
+		fun `throws SimulationException when state is invalid`() {
+			assertFailure {
+				requireSimulationState(false) { "Invalid state message" }
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Invalid state message")
+		}
+
+		@Test
+		fun `uses default message when not provided`() {
+			assertFailure {
+				requireSimulationState(false)
+			}.isInstanceOf<SimulationException>()
+				.hasMessageContaining("Invalid simulation state")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireSimulationState(true, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireEditor")
+	inner class RequireEditorTests {
+		@Test
+		fun `passes when condition is true`() {
+			requireEditor(true) { "Should not be thrown" }
+		}
+
+		@Test
+		fun `throws EditorException when false`() {
+			assertFailure {
+				requireEditor(false) { "Test editor failure" }
+			}.isInstanceOf<EditorException>()
+				.hasMessageContaining("Test editor failure")
+		}
+
+		@Test
+		fun `uses default message when not provided`() {
+			assertFailure {
+				requireEditor(false)
+			}.isInstanceOf<EditorException>()
+				.hasMessageContaining("Editor requirement failed")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireEditor(true, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireEditor with Severity")
+	inner class RequireEditorSeverityTests {
+		@Test
+		fun `passes when condition is true with severity`() {
+			requireEditor(true, Severity.ERROR) { "Should not be thrown" }
+		}
+
+		@ParameterizedTest(name = "severity {0}")
+		@EnumSource(Severity::class, names = ["FATAL", "ERROR", "WARN"])
+		fun `throws EditorException with correct severity`(severity: Severity) {
+			assertFailure {
+				requireEditor(false, severity) { "$severity editor message" }
+			}.isInstanceOf<EditorException>().all {
+				hasMessage("$severity editor message")
+				prop(EditorException::severity).isEqualTo(severity)
+			}
+		}
+
+		@Test
+		fun `uses default message with severity when not provided`() {
+			assertFailure {
+				requireEditor(false, Severity.ERROR)
+			}.isInstanceOf<EditorException>()
+				.hasMessageContaining("Editor requirement failed")
+		}
+	}
+
+	@Nested
+	@DisplayName("requireEditorNotNull")
+	inner class RequireEditorNotNullTests {
+		@Test
+		fun `returns value when not null`() {
+			val value = "editor value"
+			val result = requireEditorNotNull(value) { "Should not be thrown" }
+			assertThat(result).isEqualTo(value)
+		}
+
+		@Test
+		fun `throws EditorException when null`() {
+			assertFailure {
+				requireEditorNotNull(null) { "Editor value was null" }
+			}.isInstanceOf<EditorException>()
+				.hasMessageContaining("Editor value was null")
+		}
+
+		@Test
+		fun `uses default message when null and no message provided`() {
+			assertFailure {
+				requireEditorNotNull(null)
+			}.isInstanceOf<EditorException>()
+				.hasMessageContaining("Required value was null")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val value = "not null"
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireEditorNotNull(value, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireValidArgument")
+	inner class RequireValidArgumentTests {
+		@Test
+		fun `passes when condition is true`() {
+			requireValidArgument(true) { "Should not be thrown" }
+		}
+
+		@Test
+		fun `throws IllegalArgumentException when false`() {
+			assertFailure {
+				requireValidArgument(false) { "Invalid argument message" }
+			}.isInstanceOf<IllegalArgumentException>()
+				.hasMessageContaining("Invalid argument message")
+		}
+
+		@Test
+		fun `uses default message when not provided`() {
+			assertFailure {
+				requireValidArgument(false)
+			}.isInstanceOf<IllegalArgumentException>()
+				.hasMessageContaining("Invalid argument")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireValidArgument(true, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("requireValidState")
+	inner class RequireValidStateTests {
+		@Test
+		fun `passes when condition is true`() {
+			requireValidState(true) { "Should not be thrown" }
+		}
+
+		@Test
+		fun `throws IllegalStateException when false`() {
+			assertFailure {
+				requireValidState(false) { "Invalid state message" }
+			}.isInstanceOf<IllegalStateException>()
+				.hasMessageContaining("Invalid state message")
+		}
+
+		@Test
+		fun `uses default message when not provided`() {
+			assertFailure {
+				requireValidState(false)
+			}.isInstanceOf<IllegalStateException>()
+				.hasMessageContaining("Invalid state")
+		}
+
+		@Test
+		fun `evaluates message lazily`() {
+			var messageEvaluated = false
+			val lazyMessage = {
+				messageEvaluated = true
+				"Lazy message"
+			}
+			requireValidState(true, lazyMessage)
+			assertThat(messageEvaluated).isEqualTo(false)
+		}
+	}
+}

--- a/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/AbstractPathTest.kt
+++ b/core/src/jvmTest/kotlin/cz/vutbr/fit/interlockSim/objects/paths/AbstractPathTest.kt
@@ -10,9 +10,11 @@
  */
 package cz.vutbr.fit.interlockSim.objects.paths
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
@@ -20,7 +22,9 @@ import cz.vutbr.fit.interlockSim.objects.cells.InOut
 import cz.vutbr.fit.interlockSim.objects.cells.RailSemaphore
 import cz.vutbr.fit.interlockSim.objects.cells.RailSwitch
 import cz.vutbr.fit.interlockSim.objects.core.Cell
+import cz.vutbr.fit.interlockSim.objects.core.TrackFacility
 import cz.vutbr.fit.interlockSim.objects.tracks.SimpleTrackBlock
+import cz.vutbr.fit.interlockSim.testutil.createMockTrackOccupant
 import cz.vutbr.fit.interlockSim.testutil.KoinTestBase
 import cz.vutbr.fit.interlockSim.testutil.MockNodeCell
 import cz.vutbr.fit.interlockSim.testutil.MockSimulationContext
@@ -858,6 +862,65 @@ class AbstractPathTest : KoinTestBase() {
 			assertThat(context)
 				.withMessage("context should be the same as provided")
 				.isEqualTo(mockContext)
+		}
+	}
+
+	/**
+	 * Nested test group: Aggregate Operations
+	 * Paths are aggregates — track-facility operations (enter/leave/getTrackOccupant)
+	 * must raise UnsupportedOperationException, while getState() must return FREE as a
+	 * safe default. Covers Issue #453 coverage gap in AbstractPath.
+	 */
+	@Nested
+	@DisplayName("Aggregate Operation Semantics (Issue #453)")
+	inner class AggregateOperationTests {
+		private fun buildPath(): ArrayPath {
+			val track = SimpleTrackBlock(end1, end2, 100.0, 80.0)
+			val path = ArrayPath(mockContext)
+			path.addFirst(end1)
+			path.addLast(track)
+			path.addLast(end2)
+			return path
+		}
+
+		@Test
+		fun `getState returns FREE for path aggregate`() {
+			val path = buildPath()
+
+			val state = path.getState()
+
+			assertThat(state)
+				.withMessage("Path aggregate getState() should return FREE")
+				.isEqualTo(TrackFacility.State.FREE)
+		}
+
+		@Test
+		fun `enter throws UnsupportedOperationException`() {
+			val path = buildPath()
+			val occupant = createMockTrackOccupant(name = "T1")
+
+			assertFailure {
+				path.enter(occupant)
+			}.isInstanceOf<UnsupportedOperationException>()
+		}
+
+		@Test
+		fun `leave throws UnsupportedOperationException`() {
+			val path = buildPath()
+			val occupant = createMockTrackOccupant(name = "T1")
+
+			assertFailure {
+				path.leave(occupant)
+			}.isInstanceOf<UnsupportedOperationException>()
+		}
+
+		@Test
+		fun `getTrackOccupant throws UnsupportedOperationException`() {
+			val path = buildPath()
+
+			assertFailure {
+				path.getTrackOccupant()
+			}.isInstanceOf<UnsupportedOperationException>()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Implements #453 — next-volume coverage bump for the four lowest-covered packages. Test-only PR; no production code is modified.

Key moves:
- Relocated RequireFunctionsTest and EditorExceptionTest from :desktop-ui into :core. The Require* helpers are `inline`, so their bodies get inlined at call sites — tests must live in :core for :core JaCoCo to attribute them. EditorException (core class) was previously 0/14 lines in :core; now 14/14.
- Added ContextExceptionsTest covering every constructor of EmptyContextException and ContextCreationException.
- Added ReservationResultTest exercising PathReservationService.ReservationResult sealed subtypes (NoPathExists, Conflict, AllPathsBlocked, Success) — including data-class equality/hashCode/copy/componentN.
- Extended AbstractPathTest with an AggregateOperationTests nested class covering getState() (returns FREE) and the three aggregate UnsupportedOperationException paths (enter/leave/getTrackOccupant).

Total: +82 tests in :core (1777 → 1859), all green.

## Coverage delta (:core JaCoCo, LINE)

| Package                           | Before  | After   | Δ       |
|-----------------------------------|---------|---------|---------|
| cz.v.f.i.context                  | 69.6%   | 70.4%   | +0.8    |
| cz.v.f.i.context.navigation       | 69.2%   | 69.8%   | +0.6    |
| cz.v.f.i.objects.paths            | 61.3%   | 64.0%   | +2.7    |
| cz.v.f.i.exceptions               | 31.5%   | 47.2%   | +15.7   |
| **:core overall (LINE)**          | **63.1%** | **63.8%** | **+0.7** |
| **:core overall (INSTR)**         | **61.6%** | **62.3%** | **+0.7** |

Note: the issue's 74% → 84% target is the project-wide Sonar/aggregated figure; this PR moves the :core slice, which is where the targeted packages live. Aggregated across :core + :desktop-ui JaCoCo, the four target packages now sit at: context 78.6%, navigation 74.0%, paths 83.8%, exceptions 47.2% (LINE).

Classes whose coverage moved:
- exceptions.EditorException: 0 → 100% lines
- context.EmptyContextException: 0 → 100% lines
- context.ContextCreationException: 50 → 100% lines
- context.navigation.PathReservationService\$ReservationResult\$Conflict: 0 → 100% lines
- context.navigation.PathReservationService\$ReservationResult\$NoPathExists: 0 → 100% lines
- objects.paths.AbstractPath: +7 lines covered (getState + enter/leave/getTrackOccupant branches)

## Scope

Test-only. No production code modified.

Paths intentionally skipped (require production changes or are logging-only):
- RequireFunctionsKt body (45 lines): `inline` functions — bytecode lives at call sites, JaCoCo cannot attribute to the file itself. Not fixable without de-inlining (production change, out of scope).
- PathReservationRegistry uncovered lines: almost entirely info/debug log lambdas and edge branches in mergePathInfo — leaving for a later volume.
- DefaultSimulationContext \$run\$4, ContextKt \$1 lambdas: synthetic lambdas; not worth targeting.

## Test plan
- [x] ktlintCheck + detekt — PASS
- [x] :core:jvmTest (1859 tests, 0 failing)
- [x] test (437 desktop-ui tests, 0 failing)
- [x] integrationTest (178 tests, 0 failing)
- [x] jacocoTestReport regenerated — numbers above
- [ ] CI green on Gradle Java 21
- [ ] SonarCloud new-code coverage gate

Closes #453 (partial — this is the "next volume", not the final push to 84%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)