### PR TITLE
chore: :core KMP extraction review follow-up (#386)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,9 +94,17 @@ sonar {
         property("sonar.projectName", "interlockSim - Railway Interlocking Simulator")
         property("sonar.projectVersion", version.toString())
 
-        // Source and test paths (desktop-ui + :core KMP subproject)
-        property("sonar.sources",        "desktop-ui/src/main/kotlin,core/src/commonMain/kotlin")
-        property("sonar.tests",          "desktop-ui/src/test/kotlin,core/src/commonTest/kotlin")
+        // Source and test paths (desktop-ui + :core KMP subproject).
+        // Kept in sync with sonar-project.properties (used for local sonar-scanner runs).
+        property(
+            "sonar.sources",
+            "desktop-ui/src/main/kotlin,core/src/commonMain/kotlin," +
+                "core/src/jvmMain/kotlin,core/src/nativeMain/kotlin",
+        )
+        property(
+            "sonar.tests",
+            "desktop-ui/src/test/kotlin,core/src/commonTest/kotlin,core/src/jvmTest/kotlin",
+        )
         property("sonar.java.binaries",  "desktop-ui/build/classes/kotlin/main,core/build/classes/kotlin/jvm/main")
         property("sonar.java.test.binaries", "desktop-ui/build/classes/kotlin/test,core/build/classes/kotlin/jvm/test")
 
@@ -118,7 +126,7 @@ sonar {
                 "core/build/reports/jacoco/jvmTest/jacocoTestReport.xml",
         )
 
-        property("sonar.sourceEncoding", "ISO-8859-1")
+        property("sonar.sourceEncoding", "UTF-8")
         property("sonar.qualitygate.wait", "false")
 
         // :fast-sim compiles to linuxX64 native — JaCoCo cannot instrument native code.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,32 +2,35 @@
  * core/build.gradle.kts
  *
  * Gradle build configuration for interlockSim :core module
- * Uses Kotlin Multiplatform (JVM-only target initially)
+ * Uses Kotlin Multiplatform (JVM primary runtime target, with linuxX64
+ * also configured for native compilation/testing)
  * Extracts domain, context, objects, sim, util, exceptions packages
  *
  * ## commonMain vs JVM target
  *
- * Only the JVM target is currently compiled, so `commonMain` code is
- * effectively JVM-only today. The Kotlin Multiplatform plugin was
- * chosen deliberately to keep the future path open:
+ * The JVM target is currently the primary runtime target, and linuxX64
+ * is also configured for native compilation/testing. `commonMain` is
+ * still effectively JVM-constrained today. The Kotlin Multiplatform
+ * plugin was chosen deliberately to keep the future path open:
  *
- *  1. Future non-JVM targets (JS for a web demo, linuxX64 for
- *     :fast-sim-style native CLIs) can be added by registering a new
- *     `kotlin { ... }` target; commonMain stays portable.
+ *  1. Additional non-JVM targets (for example JS for a web demo) can
+ *     be added by registering a new `kotlin { ... }` target;
+ *     commonMain stays portable.
  *  2. The long-term simulation engine target is Kalasim
  *     (Kotlin-coroutines-based, Phase 2 in docs/jdisco-research.md),
  *     which benefits from commonMain staying free of JVM-only APIs.
- *  3. The current blocker for enabling non-JVM targets is that the
- *     `cz.hovorka.kdisco:kdisco-core-jvm` artifact consumed here is
- *     JVM-only. kDisco native variants exist from 0.4.0, but this
- *     module pulls the `-jvm` variant. Until that dependency is
- *     replaced or produces multiplatform artifacts consumed here,
- *     commonMain is functionally JVM-only.
+ *  3. kDisco 0.4.0 ships multiplatform artifacts (jvm + linuxX64
+ *     klibs) and this module consumes the multiplatform coordinate
+ *     (`cz.hovorka.kdisco:kdisco-core`; see commonMain dependencies
+ *     below). Remaining blockers for fully portable common code are
+ *     test infrastructure (MockK/JUnit5 are JVM-only; commonTest is
+ *     restricted to kotlin.test) and a Koin/xmlutil native audit on
+ *     all intended targets.
  *
- * The `checkCoreCommonMainPurity` task (defined in the root
- * build.gradle.kts) enforces that commonMain stays free of `java.*` /
- * `javax.*` imports so the day a non-JVM target is enabled, nothing
- * in commonMain has to move.
+ * The `checkCoreCommonMainPurity` task (declared later in this file
+ * under "CommonMain Purity Gate") enforces that commonMain stays free
+ * of `java.*` / `javax.*` imports so the day a non-JVM target is
+ * enabled, nothing in commonMain has to move.
  */
 
 plugins {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,6 +4,30 @@
  * Gradle build configuration for interlockSim :core module
  * Uses Kotlin Multiplatform (JVM-only target initially)
  * Extracts domain, context, objects, sim, util, exceptions packages
+ *
+ * ## commonMain vs JVM target
+ *
+ * Only the JVM target is currently compiled, so `commonMain` code is
+ * effectively JVM-only today. The Kotlin Multiplatform plugin was
+ * chosen deliberately to keep the future path open:
+ *
+ *  1. Future non-JVM targets (JS for a web demo, linuxX64 for
+ *     :fast-sim-style native CLIs) can be added by registering a new
+ *     `kotlin { ... }` target; commonMain stays portable.
+ *  2. The long-term simulation engine target is Kalasim
+ *     (Kotlin-coroutines-based, Phase 2 in docs/jdisco-research.md),
+ *     which benefits from commonMain staying free of JVM-only APIs.
+ *  3. The current blocker for enabling non-JVM targets is that the
+ *     `cz.hovorka.kdisco:kdisco-core-jvm` artifact consumed here is
+ *     JVM-only. kDisco native variants exist from 0.4.0, but this
+ *     module pulls the `-jvm` variant. Until that dependency is
+ *     replaced or produces multiplatform artifacts consumed here,
+ *     commonMain is functionally JVM-only.
+ *
+ * The `checkCoreCommonMainPurity` task (defined in the root
+ * build.gradle.kts) enforces that commonMain stays free of `java.*` /
+ * `javax.*` imports so the day a non-JVM target is enabled, nothing
+ * in commonMain has to move.
  */
 
 plugins {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,9 @@ sonar.projectVersion=1.0
 sonar.organization=bedahovorka
 
 # Source code location (Kotlin; :core KMP subproject + :desktop-ui JVM subproject)
-sonar.sources=desktop-ui/src/main/kotlin,core/src/commonMain/kotlin,core/src/jvmMain/kotlin
+sonar.sources=desktop-ui/src/main/kotlin,core/src/commonMain/kotlin,core/src/jvmMain/kotlin,core/src/nativeMain/kotlin
+# sonar.tests: no nativeTest entry yet — add core/src/nativeTest/kotlin here
+# if native test sources are introduced (keeps symmetry with nativeMain above).
 sonar.tests=desktop-ui/src/test/kotlin,core/src/commonTest/kotlin,core/src/jvmTest/kotlin
 
 # Source encoding — UTF-8 is the project default (see .editorconfig);
@@ -23,7 +25,9 @@ sonar.tests=desktop-ui/src/test/kotlin,core/src/commonTest/kotlin,core/src/jvmTe
 sonar.java.source=21
 sonar.java.target=21
 
-# Binary locations (compiled classes — dual-module)
+# Binary locations (compiled classes — dual-module).
+# Native (linuxX64) compilations are intentionally excluded: SonarCloud's
+# Kotlin analyzer operates from sources, and java.binaries is JVM-only.
 sonar.java.binaries=desktop-ui/build/classes/kotlin/main,core/build/classes/kotlin/jvm/main
 sonar.java.test.binaries=desktop-ui/build/classes/kotlin/test,core/build/classes/kotlin/jvm/test
 
@@ -31,7 +35,7 @@ sonar.java.test.binaries=desktop-ui/build/classes/kotlin/test,core/build/classes
 # sonar.java.libraries=build/libs/*.jar,~/.m2/repository/**/*.jar
 
 # Test execution and coverage reports (dual-module)
-sonar.junit.reportPaths=desktop-ui/build/test-results/test,core/build/test-results/jvmTest
+sonar.junit.reportPaths=desktop-ui/build/test-results/test,desktop-ui/build/test-results/integrationTest,core/build/test-results/jvmTest,core/build/test-results/integrationTest
 sonar.coverage.jacoco.xmlReportPaths=desktop-ui/build/reports/jacoco/test/jacocoTestReport.xml,core/build/reports/jacoco/jvmTest/jacocoTestReport.xml
 
 # Project links (optional - useful for GitHub integration)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,8 +18,8 @@ sonar.sources=desktop-ui/src/main/kotlin,core/src/commonMain/kotlin,core/src/jvm
 # if native test sources are introduced (keeps symmetry with nativeMain above).
 sonar.tests=desktop-ui/src/test/kotlin,core/src/commonTest/kotlin,core/src/jvmTest/kotlin
 
-# Source encoding — UTF-8 is the project default (see .editorconfig);
-# no explicit override needed.
+# Source encoding — UTF-8 is the project default (see .editorconfig).
+sonar.sourceEncoding=UTF-8
 
 # Java version (Java 21 LTS)
 sonar.java.source=21

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,27 +12,27 @@ sonar.projectVersion=1.0
 # Organization (required for SonarCloud)
 sonar.organization=bedahovorka
 
-# Source code location
-sonar.sources=src/main/java
-sonar.tests=src/test/java
+# Source code location (Kotlin; :core KMP subproject + :desktop-ui JVM subproject)
+sonar.sources=desktop-ui/src/main/kotlin,core/src/commonMain/kotlin,core/src/jvmMain/kotlin
+sonar.tests=desktop-ui/src/test/kotlin,core/src/commonTest/kotlin,core/src/jvmTest/kotlin
 
-# Java source encoding (legacy requirement)
-sonar.sourceEncoding=ISO-8859-1
+# Source encoding — UTF-8 is the project default (see .editorconfig);
+# no explicit override needed.
 
-# Java version
-sonar.java.source=11
-sonar.java.target=11
+# Java version (Java 21 LTS)
+sonar.java.source=21
+sonar.java.target=21
 
-# Binary locations (compiled classes)
-sonar.java.binaries=build/classes/java/main
-sonar.java.test.binaries=build/classes/java/test
+# Binary locations (compiled classes — dual-module)
+sonar.java.binaries=desktop-ui/build/classes/kotlin/main,core/build/classes/kotlin/jvm/main
+sonar.java.test.binaries=desktop-ui/build/classes/kotlin/test,core/build/classes/kotlin/jvm/test
 
 # Library dependencies (optional - helps with better analysis)
 # sonar.java.libraries=build/libs/*.jar,~/.m2/repository/**/*.jar
 
-# Test execution and coverage reports
-sonar.junit.reportPaths=build/test-results/test
-sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+# Test execution and coverage reports (dual-module)
+sonar.junit.reportPaths=desktop-ui/build/test-results/test,core/build/test-results/jvmTest
+sonar.coverage.jacoco.xmlReportPaths=desktop-ui/build/reports/jacoco/test/jacocoTestReport.xml,core/build/reports/jacoco/jvmTest/jacocoTestReport.xml
 
 # Project links (optional - useful for GitHub integration)
 # sonar.links.homepage=https://github.com/bedavs/interlockSim


### PR DESCRIPTION
## Summary

Closes **#386** — the PR #385 :core KMP extraction review follow-up. When I checked the five sub-items against current `develop`, items (1) and (3) are already done; (2) and (4) had real work; (5) is deferred until SonarCloud produces fresh output on this PR.

## Sub-items

| # | Title | Status |
|---|-------|--------|
| 1 | Fix orphaned `// Wire :core integration tests…` comment | **Already done on develop** — grep finds no match in any `build.gradle.kts` |
| 2 | Add `commonMain` clarification in `core/build.gradle.kts` | **Fixed in `5090ec0`** — three-point rationale (future non-JVM targets, Kalasim Phase 2, kDisco `-jvm` blocker) plus reference to the `checkCoreCommonMainPurity` gate |
| 3 | Use `XMLContextFactory.MIN_INOUT_ELEMENTS` constant in `InOutValidationTest.kt` | **Already done on develop** — no `val min = 1` hardcode remains |
| 4 | Fix stale `sonar-project.properties` | **Fixed in `7df6e66`** — every key rewritten for the dual-module Kotlin 21 layout; all paths verified to exist on disk after `./gradlew build test jacocoTestReport`. Note: :core's JaCoCo report lives at `core/build/reports/jacoco/jvmTest/jacocoTestReport.xml` (not `jacoco/test/...`), which the issue body had incorrect |
| 5 | SonarQube C-reliability bugs from PR #385 | **Deferred** — will address in a follow-up commit on this branch once SonarCloud publishes the scan of this PR. Cannot scope offline: inline annotations aren't exposed via `gh api` for this project |

## Test plan

- [x] `./gradlew :core:checkCoreCommonMainPurity` — passes
- [x] `./gradlew build test jacocoTestReport` — passes
- [x] `./gradlew integrationTest` — passes
- [x] `./gradlew detekt ktlintCheck` — passes
- [ ] CI green on Gradle Java 21
- [ ] SonarCloud scan — the point of this PR is that Sonar can now measure the project correctly; once it scans, any C-reliability findings from PR #385's residue get a follow-up commit here

## Election context

Winner of the 2026-04-14 round-2 backlog election (weighted total 47.0). Top issues it unblocks: #406 (ktlint on :core, score 2), #376 (SonarCloud new-code coverage gate, score 2 — directly enabled by this PR's sonar properties fix), plus siblings #407, #412, #387, #378, #379, #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)