### PR TITLE
docs(sim): Motor extends Continuous by design (#373)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ For complete navigation services architecture, Koin DI integration patterns, and
 
 **Simulation engine:**
 - Built on kDisco library (`cz.hovorka.kdisco:kdisco-core-jvm:0.3.0`) — replaces jDisco entirely (Phase 1 migration complete 2026-03-04)
-- kDisco repo: https://github.com/bedavs/kdisco
+- kDisco repo: https://github.com/bedaHovorka/kdisco
 - `sim/` package contains simulation processes (e.g., `ShuntingLoop`)
 
 **GUI:**
@@ -265,7 +265,7 @@ See **[docs/KOTLIN_STYLE_GUIDE.md](docs/KOTLIN_STYLE_GUIDE.md)** for complete co
 - **Koin injection allowed** - The Koin restriction was lifted 2026-03-20 (kDisco Phase 1 complete)
 
 **kDisco Library:**
-- **Do not modify** - Maintained as separate project at https://github.com/bedavs/kdisco
+- **Do not modify** - Maintained as separate project at https://github.com/bedaHovorka/kdisco
 
 ### Flexible Development (Other Components)
 

--- a/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/Train.kt
+++ b/core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/Train.kt
@@ -620,13 +620,17 @@ class Train :
 		): Boolean = if (isDecelarate()) targetSpeed >= velocity else targetSpeed <= velocity
 	}
 
-	// Motor extends Continuous (not LoopProcess) because it requires ODE-based physics integration
-	// via derivatives(). LoopProcess extends Process (discrete-only) and cannot provide continuous
-	// integration. Motor uses Continuous.start()/stop() to activate/deactivate the ODE integrator
-	// per acceleration phase, while the terminate flag provides graceful shutdown (safe to reimplement
-	// here because Motor cannot inherit from LoopProcess). The "continuous simulation not required"
-	// determination in the decision docs refers to the framework choice (DSOL vs kDisco), not to
-	// Motor's kinematics, which have always been ODE-based. See: #373
+	/**
+	 * Extends [Continuous] (not [LoopProcess]/`Process`) because train kinematics require
+	 * ODE integration via [derivatives]; [start]/[stop] gate integration per acceleration
+	 * phase. The project-level "continuous simulation not required" finding concerns
+	 * framework choice (DSOL vs kDisco), not Motor's internal physics.
+	 *
+	 * The private `terminate` flag mirrors the [LoopProcess] shutdown pattern — necessary
+	 * duplication, because Motor cannot inherit it (LoopProcess is Process-based, discrete).
+	 *
+	 * See `docs/MOTOR_CONTINUOUS_RATIONALE.md` (issue #373).
+	 */
 	private inner class Motor : Continuous() {
 		private var currentCondition: AccelerationStopCondition? = null
 		private var targetSpeed: Double = 0.0

--- a/docs/MOTOR_CONTINUOUS_RATIONALE.md
+++ b/docs/MOTOR_CONTINUOUS_RATIONALE.md
@@ -17,19 +17,20 @@ This document records the traffic-simulation-expert's (TSE) arbitration of
 that concern. The code keeps `Motor : Continuous()` and a short KDoc at the
 class site; the full argument lives here.
 
-## kDisco type hierarchy
+## Type hierarchy (relevant classes)
 
 ```
-Link
-└── Process          (discrete-event entity)
-    ├── Continuous   (adds ODE integration: derivatives(), start(), stop())
-    └── LoopProcess  (discrete-only cooperative loop)
+Link                        ← kDisco
+└── Process                 ← kDisco        (discrete-event entity)
+    ├── Continuous          ← kDisco        (adds ODE integration: derivatives(), start(), stop())
+    └── LoopProcess         ← interlockSim  (discrete-only cooperative loop)
 ```
 
-- `LoopProcess : Process()` — no `derivatives()`, no integrator, no
-  `start()`/`stop()`.
-- `Continuous : Process()` — the only kDisco base class that provides an
-  ODE integrator and per-phase activation/deactivation of that integrator.
+- `Continuous : Process()` — kDisco class; the only base that provides an ODE
+  integrator and per-phase activation/deactivation of that integrator.
+- `LoopProcess : Process()` — project-local class in
+  `cz.vutbr.fit.interlockSim.sim`; discrete-only, no `derivatives()`,
+  no `start()`/`stop()`.
 
 ## Why `Continuous` is required
 
@@ -90,8 +91,9 @@ trait/mixin for two classes.
 ## References
 
 - Code: `core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/Train.kt`
-  — `Motor` class header at line 623, `Motor.derivatives()` at line 735
+  — search for `private inner class Motor : Continuous()` and
+  `override fun derivatives()`
 - Code: `core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/LoopProcess.kt`
-- kDisco: <https://github.com/bedavs/kdisco>
+- kDisco: <https://github.com/bedaHovorka/kdisco/>
 - Issue: [#373](https://github.com/bedaHovorka/interlockSim/issues/373)
 - PR: [#372](https://github.com/bedaHovorka/interlockSim/pull/372)

--- a/docs/MOTOR_CONTINUOUS_RATIONALE.md
+++ b/docs/MOTOR_CONTINUOUS_RATIONALE.md
@@ -1,0 +1,97 @@
+# Motor Inner Class — Why it Extends `Continuous`
+
+**Status:** Architectural record — resolves #373 (2026-04-20)
+**Author:** traffic-simulation-expert (see [`TEAM.md`](../TEAM.md))
+**Scope:** The `Motor` inner class in
+`core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/Train.kt`.
+
+## Context
+
+During review of [PR #372](https://github.com/bedaHovorka/interlockSim/pull/372)
+(kDisco Phase 1 migration) a reviewer flagged `Motor : Continuous()` as a
+CRITICAL concern. The reasoning was that the project's decision documents had
+concluded *"continuous simulation is NOT required"* — so why does `Motor`
+extend kDisco's ODE-integration base class?
+
+This document records the traffic-simulation-expert's (TSE) arbitration of
+that concern. The code keeps `Motor : Continuous()` and a short KDoc at the
+class site; the full argument lives here.
+
+## kDisco type hierarchy
+
+```
+Link
+└── Process          (discrete-event entity)
+    ├── Continuous   (adds ODE integration: derivatives(), start(), stop())
+    └── LoopProcess  (discrete-only cooperative loop)
+```
+
+- `LoopProcess : Process()` — no `derivatives()`, no integrator, no
+  `start()`/`stop()`.
+- `Continuous : Process()` — the only kDisco base class that provides an
+  ODE integrator and per-phase activation/deactivation of that integrator.
+
+## Why `Continuous` is required
+
+The `Motor` inner class models train kinematics. Its `derivatives()` override
+is what actually advances velocity and position between discrete events.
+Without `Continuous` there is nowhere to put `derivatives()`; without
+`start()`/`stop()` the integrator cannot be gated to an acceleration phase.
+
+Concretely, `Motor`:
+
+- overrides `derivatives()` — only `Continuous` invokes this hook;
+- calls `start()` when an acceleration phase begins, and `stop()` when it ends;
+- uses `waitUntil(condition)` on the discrete side of the same object to
+  interleave the integrator's activity with event-driven control flow.
+
+`LoopProcess` (or plain `Process`) cannot host any of this.
+
+## Framework decision ≠ implementation physics
+
+The *"continuous simulation is NOT required"* line in the decision documents
+is a **framework-level** statement. It answers the question *"should we adopt
+a library built around ODE solvers (DSOL) or a discrete-event library that
+we extend ourselves (kDisco)?"*. The answer was: kDisco.
+
+That answer says nothing about how individual classes inside the project
+compute motion. `Motor` has always used ODE-integrated kinematics — before
+and after the jDisco→kDisco migration — because there is no practical
+discrete substitute for continuously-evolving train dynamics during an
+acceleration phase.
+
+Cross-references:
+
+- [`docs/SIMULATION_LIBRARY_DECISION.md`](./SIMULATION_LIBRARY_DECISION.md)
+- [`docs/SIMULATION_LIBRARY_DECISION_ROUND2.md`](./SIMULATION_LIBRARY_DECISION_ROUND2.md)
+- [`docs/DECISION_AUDIT_AND_EXPERTISE.md`](./DECISION_AUDIT_AND_EXPERTISE.md)
+
+## `terminate` flag — duplication, not redundancy
+
+`Motor` carries a private `terminate: Boolean` flag that mirrors the
+cooperative-shutdown protocol in `LoopProcess`. This is duplicated *on
+purpose*:
+
+- `TrainReporter` (sibling inner class in the same file) extends
+  `LoopProcess` and inherits the pattern for free.
+- `Motor` cannot extend `LoopProcess` (it needs `Continuous`), so it
+  reimplements the minimal pattern — one flag, checked in `actions()` — to
+  achieve the same safe shutdown.
+
+The duplication is narrow and stable; it does not warrant a shared
+trait/mixin for two classes.
+
+## Non-goals
+
+- No change to `Motor`'s runtime behavior.
+- No new formulas, no change to kinematics.
+- No reopening of the kDisco-vs-DSOL-vs-Kalasim framework decision.
+
+## References
+
+- Code: `core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/Train.kt`
+  — `Motor` class header at line 623, `Motor.derivatives()` at line 735
+- Code: `core/src/commonMain/kotlin/cz/vutbr/fit/interlockSim/sim/LoopProcess.kt`
+- kDisco: <https://github.com/bedavs/kdisco>
+- Issue: [#373](https://github.com/bedaHovorka/interlockSim/issues/373)
+- PR: [#372](https://github.com/bedaHovorka/interlockSim/pull/372)


### PR DESCRIPTION
## Summary
- Replace 7-line `//` block above `Motor : Continuous()` in `Train.kt` with a terse KDoc pointer
- Add `docs/MOTOR_CONTINUOUS_RATIONALE.md` — full TSE-authored architectural record

## Context
PR #372 review flagged `Motor : Continuous()` as CRITICAL, conflating the framework-level *"continuous simulation not required"* finding with Motor's internal ODE-based kinematics. The inline annotation has been trimmed to a pointer; the full architectural argument now lives in the new doc.

## traffic-simulation-expert review — resolves #373
Reviewed — `Motor` correctly extends kDisco's `Continuous` because:
1. `derivatives()` has no equivalent on `Process` / `LoopProcess`.
2. `start()` / `stop()` gate ODE integration per acceleration phase.
3. The *"continuous simulation not required"* finding in the decision docs concerns framework choice (DSOL vs kDisco vs Kalasim), not Motor's internals.

The `terminate` flag is a necessary (narrow) duplication of the `LoopProcess` shutdown pattern — Motor cannot inherit it because it extends `Continuous` instead.

Doc-only; no runtime behavior change. Golden outputs unaffected.

## Test plan
- [x] `./gradlew :core:detekt :core:ktlintCheck` passes
- [x] `./gradlew :core:jvmTest` passes (1886/1886)
- [x] `./gradlew integrationTest` passes (455/455)
- [ ] Rendered KDoc symbol links (`[Continuous]`, `[LoopProcess]`, `[derivatives]`, `[start]`, `[stop]`) resolve in IDE

Closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)