### PR TITLE
fix(goal-8): resolve potential S/T keyboard shortcut conflicts (#511)

### DIFF
--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/MenuBar.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/MenuBar.kt
@@ -400,8 +400,12 @@ class MenuBar : JMenuBar() {
 	 * Builds the "Simulation" menu with Start/Stop actions and a Speed submenu.
 	 *
 	 * Speed presets (0.1x, 0.5x, 1x, 2x, 5x, 10x, 50x) are available via menu items.
-	 * Global keyboard shortcuts (keys 1–5, +/-, Space) are handled by [SimulationKeyBindings]
-	 * during simulation mode (Phase 3.1, Issue #193).
+	 * Global keyboard shortcuts (keys 1–5, +/-, Space, S, T) are handled by
+	 * [SimulationKeyBindings] during simulation mode (Phase 3.1, Issue #193; Goal 8).
+	 *
+	 * **Shortcut reservation:** Keys `S` (step event) and `T` (step time) are reserved
+	 * for simulation-mode step controls. Menu items in this application must not use
+	 * `S` or `T` as mnemonics or accelerators, to avoid conflicts with those bindings.
 	 */
 	private fun simulationMenu(): JMenu {
 		val menu = JMenu("Simulation")
@@ -452,7 +456,9 @@ class MenuBar : JMenuBar() {
 					"- Key 5: 10x speed<br>" +
 					"- Plus (+): Increase speed by 1.5x<br>" +
 					"- Minus (-): Decrease speed by 1.5x<br>" +
-					"- Space: Pause/resume simulation</html>"
+					"- Space: Pause/resume simulation<br>" +
+					"- S: Step one simulation event when paused<br>" +
+					"- T: Step forward by the configured time delta when paused</html>"
 			)
 		)
 		menu.add(

--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationKeyBindings.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationKeyBindings.kt
@@ -34,6 +34,10 @@ import javax.swing.text.JTextComponent
  * Shortcuts are suppressed while a text component has keyboard focus, so typing in
  * fields such as the Step Time spinner does not accidentally trigger simulation actions.
  *
+ * Step shortcuts `S` and `T` are deliberately bound as plain keystrokes (no Alt/Ctrl
+ * modifiers). They are active only while the frame is in simulation mode and must not
+ * overlap with menu mnemonics/accelerators; [MenuBar] reserves those keys accordingly.
+ *
  * ## Usage
  * ```kotlin
  * val keyBindings = SimulationKeyBindings(frame.simulationController)

--- a/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationKeyBindingsConflictTest.kt
+++ b/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationKeyBindingsConflictTest.kt
@@ -1,0 +1,119 @@
+/* Brno University of Technology
+ * Faculty of Information Technology
+ *
+ * BSc Thesis  2006/2007
+ *
+ * Railway Interlocking Simulator
+ *
+ * SimulationKeyBindingsConflictTest — Goal 8 Issue #511: prevent shortcut conflicts
+ */
+package cz.vutbr.fit.interlockSim.gui
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotIn
+import assertk.assertions.isNull
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.JComponent
+import javax.swing.JMenu
+import javax.swing.JMenuBar
+import javax.swing.JMenuItem
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+import javax.swing.SwingUtilities
+
+/**
+ * Regression tests ensuring that the simulation step shortcuts `S` and `T` do not
+ * conflict with existing or future Swing menu mnemonics / accelerators.
+ *
+ * Issue #511: simulation-mode shortcuts must stay reserved and must not overlap
+ * with standard menu hotkeys.
+ */
+class SimulationKeyBindingsConflictTest {
+
+	private val reservedStepKeys = setOf(KeyEvent.VK_S, KeyEvent.VK_T)
+
+	/**
+	 * Verifies that no menu item in the application menu bar uses `S` or `T` as a
+	 * mnemonic or accelerator key. If a future menu item tries to claim one of those
+	 * letters, this test fails and forces an explicit conflict resolution.
+	 */
+	@Test
+	fun `menu bar does not use S or T as mnemonics or accelerators`() {
+		val menuBar = MenuBar()
+
+		forEachMenuItem(menuBar) { item ->
+			val mnemonic = item.mnemonic
+			if (mnemonic != 0) {
+				assertThat(mnemonic, "mnemonic for ${item.text}").isNotIn(reservedStepKeys)
+			}
+
+			val acceleratorKeyCode = item.accelerator?.keyCode
+			assertThat(acceleratorKeyCode, "accelerator for ${item.text}").isNotIn(reservedStepKeys)
+		}
+	}
+
+	/**
+	 * Verifies that the `S` and `T` step shortcuts are registered as plain keystrokes
+	 * without Alt or Ctrl modifiers. Using modifiers would risk collision with standard
+	 * menu accelerators (e.g. Ctrl+S "Save", Ctrl+T "New Tab", Alt+S/Alt+T mnemonics).
+	 */
+	@Test
+	fun `step shortcuts S and T are plain keystrokes without menu modifiers`() {
+		lateinit var rootPane: JPanel
+		lateinit var keyBindings: SimulationKeyBindings
+
+		SwingUtilities.invokeAndWait {
+			rootPane = JPanel()
+			keyBindings = SimulationKeyBindings(mockk(relaxed = true))
+			keyBindings.install(rootPane)
+		}
+
+		val inputMap = rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+
+		val stepEventStroke = inputMap.get(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0)) as String
+		val stepTimeStroke = inputMap.get(KeyStroke.getKeyStroke(KeyEvent.VK_T, 0)) as String
+
+		assertThat(stepEventStroke).isEqualTo("simulation_step_event")
+		assertThat(stepTimeStroke).isEqualTo("simulation_step_time")
+
+		// Ensure no Alt or Ctrl variants of these keys are bound by mistake
+		val altS = KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK)
+		val ctrlS = KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK)
+		val altT = KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.ALT_DOWN_MASK)
+		val ctrlT = KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.CTRL_DOWN_MASK)
+
+		assertThat(inputMap.get(altS), "Alt+S binding").isNull()
+		assertThat(inputMap.get(ctrlS), "Ctrl+S binding").isNull()
+		assertThat(inputMap.get(altT), "Alt+T binding").isNull()
+		assertThat(inputMap.get(ctrlT), "Ctrl+T binding").isNull()
+	}
+
+	/**
+	 * Recursively invokes [action] for every [JMenuItem] contained in [menuBar],
+	 * including nested sub-menus.
+	 */
+	private fun forEachMenuItem(menuBar: JMenuBar, action: (JMenuItem) -> Unit) {
+		val queue = ArrayDeque<JMenu>()
+		repeat(menuBar.menuCount) { index ->
+			val menu = menuBar.getMenu(index)
+			if (menu != null) queue.add(menu)
+		}
+
+		while (queue.isNotEmpty()) {
+			val menu = queue.removeFirst()
+			action(menu)
+
+			for (i in 0 until menu.itemCount) {
+				when (val item = menu.getItem(i)) {
+					is JMenu -> queue.add(item)
+					is JMenuItem -> action(item)
+					else -> { /* separators or null items are ignored */ }
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves [Goal 8 sub-task #511](https://github.com/bedaHovorka/interlockSim/issues/511): ensure the new simulation step shortcuts `S` (step event) and `T` (step time) do not conflict with existing or future Swing/AWT menu shortcuts or application-wide hotkeys.

## What changed

- **MenuBar.kt**
  - Updated the Simulation menu KDoc to state that `S` and `T` are reserved for simulation-mode step controls.
  - Added a warning that menu items must not use `S` or `T` as mnemonics or accelerators.
  - Documented `S` and `T` in the Help > Usage dialog alongside the existing speed/pause shortcuts.

- **SimulationKeyBindings.kt**
  - Enhanced KDoc to clarify that `S` and `T` are deliberately bound as plain keystrokes (no Alt/Ctrl modifiers) and are active only in simulation mode.

- **SimulationKeyBindingsConflictTest.kt** (new)
  - Regression test that recursively scans the application menu bar and asserts no menu item uses `S` or `T` as a mnemonic or accelerator.
  - Regression test that verifies `S` and `T` are bound as plain keystrokes and that no Alt/Ctrl variants are accidentally registered.

## Verification

- `./gradlew :desktop-ui:test` ✅
- `./gradlew :desktop-ui:integrationTest` ✅
- `./gradlew :desktop-ui:detekt :desktop-ui:ktlintCheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)