### PR TITLE
feat(goal-8): enforce step-time delta bounds (#512)

### DIFF
--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationControlPanel.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationControlPanel.kt
@@ -223,8 +223,8 @@ class SimulationControlPanel : JPanel() {
 		stepTimeDeltaSpinner = JSpinner(
 			SpinnerNumberModel(
 				DEFAULT_STEP_TIME_DELTA,
-				MIN_STEP_TIME_DELTA,
-				MAX_STEP_TIME_DELTA,
+				SimulationRunner.MIN_STEP_TIME_DELTA,
+				SimulationRunner.MAX_STEP_TIME_DELTA,
 				STEP_TIME_SPINNER_STEP
 			)
 		)
@@ -314,8 +314,11 @@ class SimulationControlPanel : JPanel() {
 	 * Called from the [runner] setter when a non-null runner is attached.
 	 */
 	private fun syncUiToStepTimeDelta(delta: Double) {
+		val coerced = delta.coerceIn(
+			SimulationRunner.MIN_STEP_TIME_DELTA,
+			SimulationRunner.MAX_STEP_TIME_DELTA
+		)
 		val model = stepTimeDeltaSpinner.model as SpinnerNumberModel
-		val coerced = delta.coerceIn(model.minimum as Double, model.maximum as Double)
 		if (model.value as Double != coerced) {
 			model.value = coerced
 		}
@@ -341,12 +344,6 @@ class SimulationControlPanel : JPanel() {
 
 		/** Default step-time delta (seconds). */
 		private const val DEFAULT_STEP_TIME_DELTA: Double = 1.0
-
-		/** Minimum step-time delta (seconds). */
-		private const val MIN_STEP_TIME_DELTA: Double = 0.001
-
-		/** Maximum step-time delta (seconds). */
-		private const val MAX_STEP_TIME_DELTA: Double = 60.0
 
 		/** Spinner step size for the step-time delta (seconds). */
 		private const val STEP_TIME_SPINNER_STEP: Double = 0.1

--- a/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
+++ b/desktop-ui/src/main/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunner.kt
@@ -46,7 +46,23 @@ class SimulationRunner(
 	private var stepTimeRequested: Double? = null
 
 	@Volatile
-	var stepTimeDelta: Double = 1.0
+	private var stepTimeDeltaBacking: Double = DEFAULT_STEP_TIME_DELTA
+
+	/**
+	 * Time delta used by [requestStepTime] when advancing the simulation by a
+	 * fixed amount of simulation time.
+	 *
+	 * Valid range: [MIN_STEP_TIME_DELTA]..[MAX_STEP_TIME_DELTA]. Values outside
+	 * the range throw [IllegalArgumentException].
+	 */
+	var stepTimeDelta: Double
+		get() = stepTimeDeltaBacking
+		set(value) {
+			require(value in MIN_STEP_TIME_DELTA..MAX_STEP_TIME_DELTA) {
+				"stepTimeDelta must be in [$MIN_STEP_TIME_DELTA..$MAX_STEP_TIME_DELTA], got: $value"
+			}
+			stepTimeDeltaBacking = value
+		}
 
 	@Volatile
 	private var simThread: Thread? = null
@@ -116,8 +132,8 @@ class SimulationRunner(
 	}
 
 	fun requestStepTime(simSeconds: Double) {
-		require(simSeconds > 0.0) {
-			"Step-time delta must be positive, got: $simSeconds"
+		require(simSeconds in MIN_STEP_TIME_DELTA..MAX_STEP_TIME_DELTA) {
+			"Step-time delta must be in [$MIN_STEP_TIME_DELTA..$MAX_STEP_TIME_DELTA], got: $simSeconds"
 		}
 		val oldEvent: Boolean
 		val oldTime: Double?
@@ -302,6 +318,10 @@ class SimulationRunner(
 		const val MIN_SPEED: Double = 0.1
 		const val MAX_SPEED: Double = 100.0
 		const val DEFAULT_SPEED: Double = 1.0
+
+		const val MIN_STEP_TIME_DELTA: Double = 0.001
+		const val MAX_STEP_TIME_DELTA: Double = 60.0
+		const val DEFAULT_STEP_TIME_DELTA: Double = 1.0
 
 		const val PROP_SPEED_MULTIPLIER: String = "speedMultiplier"
 		const val PROP_IS_PAUSED: String = "isPaused"

--- a/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationControlPanelButtonsTest.kt
+++ b/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationControlPanelButtonsTest.kt
@@ -13,6 +13,7 @@ package cz.vutbr.fit.interlockSim.gui
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import cz.vutbr.fit.interlockSim.context.SimulationContext
@@ -316,13 +317,21 @@ class SimulationControlPanelButtonsTest {
 	}
 
 	@Test
-	@DisplayName("spinner value is coerced into the allowed range when syncing from runner")
-	fun spinnerCoercesOutOfRangeRunnerDelta() {
+	@DisplayName("spinner rejects an out-of-range user value with ParseException")
+	fun spinnerRejectsOutOfRangeUserValue() {
 		val runner = runnerWith(paused = false)
-		runner.stepTimeDelta = 120.0
+		var parseException: java.text.ParseException? = null
 		SwingUtilities.invokeAndWait {
 			panel.runner = runner
+			val spinner = findSpinner()
+			(spinner.editor as? javax.swing.JSpinner.DefaultEditor)?.textField?.text = "120.0"
+			try {
+				spinner.commitEdit()
+			} catch (e: java.text.ParseException) {
+				parseException = e
+			}
 		}
-		assertThat(spinnerModel().value as Double).isEqualTo(60.0)
+		assertThat(parseException).isNotNull()
+		assertThat(runner.stepTimeDelta).isEqualTo(1.0)
 	}
 }

--- a/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
+++ b/desktop-ui/src/test/kotlin/cz/vutbr/fit/interlockSim/gui/SimulationRunnerTest.kt
@@ -42,9 +42,10 @@ class SimulationRunnerTest {
 	}
 
 	@Test
-	@DisplayName("defaults: speedMultiplier=1.0, isPaused=false, not running")
+	@DisplayName("defaults: speedMultiplier=1.0, stepTimeDelta=1.0, isPaused=false, not running")
 	fun defaults() {
 		assertThat(runner.speedMultiplier).isEqualTo(1.0)
+		assertThat(runner.stepTimeDelta).isEqualTo(1.0)
 		assertThat(runner.isPaused).isFalse()
 		assertThat(runner.isRunning()).isFalse()
 	}
@@ -80,6 +81,32 @@ class SimulationRunnerTest {
 	@DisplayName("speed 100.1 above upper bound throws")
 	fun speedAboveUpperBoundThrows() {
 		assertThrows(IllegalArgumentException::class.java) { runner.speedMultiplier = 100.1 }
+	}
+
+	@Test
+	@DisplayName("stepTimeDelta below 0.001 throws")
+	fun stepTimeDeltaBelowLowerBoundThrows() {
+		assertThrows(IllegalArgumentException::class.java) { runner.stepTimeDelta = 0.0009 }
+	}
+
+	@Test
+	@DisplayName("stepTimeDelta 0.001 accepted (inclusive lower bound)")
+	fun stepTimeDeltaLowerBoundAccepted() {
+		runner.stepTimeDelta = 0.001
+		assertThat(runner.stepTimeDelta).isEqualTo(0.001)
+	}
+
+	@Test
+	@DisplayName("stepTimeDelta 60.0 accepted (inclusive upper bound)")
+	fun stepTimeDeltaUpperBoundAccepted() {
+		runner.stepTimeDelta = 60.0
+		assertThat(runner.stepTimeDelta).isEqualTo(60.0)
+	}
+
+	@Test
+	@DisplayName("stepTimeDelta above 60.0 throws")
+	fun stepTimeDeltaAboveUpperBoundThrows() {
+		assertThrows(IllegalArgumentException::class.java) { runner.stepTimeDelta = 60.1 }
 	}
 
 	@Test
@@ -311,7 +338,7 @@ class SimulationRunnerTest {
 	}
 
 	@Test
-	@DisplayName("requestStepTime validates dt > 0")
+	@DisplayName("requestStepTime validates dt is within 0.001..60.0")
 	fun requestStepTimeValidation() {
 		assertThrows(IllegalArgumentException::class.java) {
 			runner.requestStepTime(0.0)
@@ -319,8 +346,16 @@ class SimulationRunnerTest {
 		assertThrows(IllegalArgumentException::class.java) {
 			runner.requestStepTime(-1.5)
 		}
-		runner.requestStepTime(0.001) // should succeed
+		assertThrows(IllegalArgumentException::class.java) {
+			runner.requestStepTime(0.0009)
+		}
+		assertThrows(IllegalArgumentException::class.java) {
+			runner.requestStepTime(60.1)
+		}
+		runner.requestStepTime(0.001) // inclusive lower bound
 		assertThat(runner.pollStepTime()).isEqualTo(0.001)
+		runner.requestStepTime(60.0) // inclusive upper bound
+		assertThat(runner.pollStepTime()).isEqualTo(60.0)
 	}
 
 	@Test


### PR DESCRIPTION
Closes #512.

Enforces the step-time delta spinner range (0.001 s - 60.0 s) in both the UI and the underlying SimulationRunner:

- Adds MIN_STEP_TIME_DELTA, MAX_STEP_TIME_DELTA, and DEFAULT_STEP_TIME_DELTA constants to SimulationRunner.
- Validates stepTimeDelta assignments against [0.001, 60.0].
- Validates requestStepTime(simSeconds) against the same range.
- Reuses the runner constants in SimulationControlPanel so the spinner model and UI sync share a single source of truth.
- Updates/extends tests for runner bounds and for UI rejection of out-of-range typed spinner values.

Quality gates run:
- ./gradlew :desktop-ui:test :desktop-ui:detekt :desktop-ui:ktlintCheck passed
- ./gradlew :desktop-ui:integrationTest passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)