### PR TITLE
feat(claude): add session-start, ktlint, and pre-push hooks

### DIFF
--- a/.claude/hooks/ktlint-check.sh
+++ b/.claude/hooks/ktlint-check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" \
+    2>/dev/null || echo "")
+
+[[ "$FILE_PATH" == *.kt ]] || exit 0
+
+if [[ "$FILE_PATH" == */core/* ]]; then
+    exec ./gradlew :core:ktlintCheck
+else
+    exec ./gradlew :desktop-ui:ktlintCheck
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+DATE=$(date '+%Y-%m-%d')
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+COMMITS=$(git log --oneline -5 2>/dev/null || echo "(no commits)")
+CHANGED=$(git diff --name-only HEAD~5 HEAD 2>/dev/null || echo "")
+
+count_files() { echo "$CHANGED" | { grep -c "^${1}/" || true; }; }
+list_files()  { echo "$CHANGED" | grep "^${1}/" | head -3 | tr '\n' ',' | sed 's/,$//'; }
+
+CORE_COUNT=$(count_files "core")
+DUI_COUNT=$(count_files "desktop-ui")
+FS_COUNT=$(count_files "fast-sim")
+CORE_LIST=$(list_files "core")
+DUI_LIST=$(list_files "desktop-ui")
+FS_LIST=$(list_files "fast-sim")
+
+fmt_subproject() {
+    local label="$1" count="$2" list="$3"
+    [[ -n "$list" ]] \
+        && echo "- ${label} -- ${count} files (${list})" \
+        || echo "- ${label} -- ${count} files"
+}
+
+S1=$(fmt_subproject ":core" "$CORE_COUNT" "$CORE_LIST")
+S2=$(fmt_subproject ":desktop-ui" "$DUI_COUNT" "$DUI_LIST")
+S3=$(fmt_subproject ":fast-sim" "$FS_COUNT" "$FS_LIST")
+
+CONTEXT="## Session Context -- ${DATE}
+
+**Branch:** ${BRANCH}
+**Last 5 commits:**
+$(echo "$COMMITS" | sed 's/^/- /')
+
+**Recent changes by subproject (last 5 commits):**
+${S1}
+${S2}
+${S3}"
+
+python3 -c "import json,sys; d=sys.stdin.read(); print(json.dumps({'hookSpecificOutput':{'hookEventName':'SessionStart','additionalContext':d}}))" <<< "$CONTEXT"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/session-start.sh",
+            "statusMessage": "Loading session context..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/ktlint-check.sh",
+            "statusMessage": "Running ktlintCheck..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./gradlew integrationTest && docker compose up --build -d",
+            "if": "Bash(git push:*)",
+            "timeout": 600,
+            "statusMessage": "Running pre-push checks (integrationTest + docker build)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,10 @@ Thumbs.db
 # Phase 0: Baseline outputs (regenerate with ./capture-golden-outputs.sh)
 # Only track metadata (README, analysis, checksums), not 22MB of .log files
 
-# Claude Code configuration (local settings and skills)
-.claude/
+# Claude Code -- ignore local/personal files; commit settings.json and hooks/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
 desktop-ui/*.xml
 
 # Pre-built kDisco artifacts for Docker — now fetched from GitHub Packages

--- a/docs/superpowers/specs/2026-06-27-claude-hooks-setup-design.md
+++ b/docs/superpowers/specs/2026-06-27-claude-hooks-setup-design.md
@@ -1,0 +1,72 @@
+# Claude Code Hooks Setup
+
+**Date:** 2026-06-27  
+**Status:** Implemented
+
+## Problem
+
+Claude was being used as a passive LLM — no automated quality gates, no live project state at session start, no enforcement of existing workflow rules (integrationTest before push).
+
+## Solution
+
+Three hooks in `.claude/settings.json` (committed to git):
+
+| Hook | Trigger | Action | Blocking? |
+|------|---------|--------|-----------|
+| SessionStart | Every new/cleared session | Inject branch + commits + subproject diff | No |
+| PostToolUse | Edit or Write on any `*.kt` file | Run subproject `ktlintCheck`, report violations | No (advisory) |
+| PreToolUse | `Bash(git push:*)` | Run `integrationTest` then `docker compose up --build -d` | Yes |
+
+## Files
+
+```
+.claude/
+├── settings.json            # Hook configuration (committed)
+└── hooks/
+    ├── session-start.sh     # Outputs branch + commits + subproject diff as JSON context
+    └── ktlint-check.sh      # Reads stdin file_path, runs subproject ktlintCheck if *.kt
+```
+
+`settings.local.json` remains gitignored (personal allow rules, unchanged).
+
+## Session-Start Output
+
+Injected as `{"context": "..."}` JSON. Example:
+
+```
+## Session Context -- 2026-06-27
+
+**Branch:** develop
+**Last 5 commits:**
+- b81fc6a docs(team): fix stale Koin sim/ restriction
+- ...
+
+**Recent changes by subproject (last 5 commits):**
+- :core         -- 36 files (core/build.gradle.kts, ...)
+- :desktop-ui   -- 54 files (desktop-ui/build.gradle.kts, ...)
+- :fast-sim     -- 11 files (fast-sim/build.gradle.kts, ...)
+```
+
+## Pre-Push Sequence
+
+```
+./gradlew integrationTest && docker compose up --build -d
+```
+
+- `integrationTest` fails → push blocked, no Docker build
+- Docker build fails → push blocked
+- Both pass → push proceeds
+
+Enforces the project rule: integration tests must pass before pushing.
+
+## .gitignore Change
+
+Replaced `.claude/` (blanket ignore) with:
+
+```gitignore
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+```
+
+This keeps `settings.local.json`, `worktrees/`, and legacy `skills/*.json` gitignored while allowing the new hooks to be committed.


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` (committed to git) with three hooks that make Claude an active development partner instead of a passive LLM
- **SessionStart**: injects current branch, last 5 commits, and subproject file-change summary into every session
- **PostToolUse** on `Edit|Write`: runs `:core:ktlintCheck` or `:desktop-ui:ktlintCheck` after any `.kt` file edit — violations reported back to Claude immediately
- **PreToolUse** on `git push`: blocks push until `./gradlew integrationTest` passes and `docker compose up --build -d` succeeds (enforces the existing project rule)
- Updates `.gitignore` from blanket `.claude/` ignore to `.claude/*` with explicit un-ignores for `settings.json` and `hooks/`, keeping `settings.local.json` local

## Test plan

- [x] Start a fresh session or run `/clear` — confirm session-start context block appears with branch + commits + subproject summary
- [x] Edit a `.kt` file — confirm ktlintCheck runs and violations (if any) are reported
- [x] Attempt `git push` with failing integration tests — confirm push is blocked
- [x] Attempt `git push` with passing tests — confirm integrationTest + docker build run before push proceeds
- [x] Run `git status` — confirm `settings.local.json` is NOT staged (still gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)