### PR TITLE
fix(docker): cache TeX Live system deps in text Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
     build:
       context: .
       dockerfile: text/Dockerfile
+      args:
+        BUILDKIT_INLINE_CACHE: 1
     image: interlocksim-text:latest
     volumes:
       # Mount local directory to extract artifacts

--- a/text/Dockerfile
+++ b/text/Dockerfile
@@ -7,35 +7,53 @@
 #      Railway Interlocking Simulator
 #
 #      Dockerization: 2025
+#      Optimized: 2026-06 (BuildKit apt cache mounts)
 #
 #      LaTeX thesis compilation with Czech language tools
 #
 
-FROM debian:bookworm-slim
+# syntax=docker/dockerfile:1.4
 
-# Install TeX Live and Czech language tools
-RUN apt-get update && apt-get install -y \
-    # Core LaTeX packages
-    texlive-latex-base \
-    texlive-latex-extra \
-    texlive-bibtex-extra \
-    texlive-fonts-recommended \
-    texlive-font-utils \
-    texlive-science \
-    # Czech language support
-    texlive-lang-czechslovak \
-    texlive-binaries \
-    # Image conversion tools
-    libwmf-bin \
-    imagemagick \
-    ghostscript \
-    # Plot generation
-    gnuplot \
-    # Build tool
-    make \
-    # Character encoding tools
-    libc-bin \
-    && rm -rf /var/lib/apt/lists/*
+# ============================================
+# Stage 1: Install TeX Live and Czech tools
+# ============================================
+FROM debian:bookworm-slim AS tex-deps
+
+# Keep downloaded .deb packages in the BuildKit apt cache across builds.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Install TeX Live and supporting tools with a persistent apt cache mount.
+# The cache mount survives across docker compose builds, so texlive packages
+# are downloaded only once (until the package list changes).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        # Core LaTeX packages
+        texlive-latex-base \
+        texlive-latex-extra \
+        texlive-bibtex-extra \
+        texlive-fonts-recommended \
+        texlive-font-utils \
+        texlive-science \
+        # Czech language support
+        texlive-lang-czechslovak \
+        texlive-binaries \
+        # Image conversion tools
+        libwmf-bin \
+        imagemagick \
+        ghostscript \
+        # Plot generation
+        gnuplot \
+        # Build tool
+        make \
+        # Character encoding tools
+        libc-bin
+
+# ============================================
+# Stage 2: Build the thesis PDF
+# ============================================
+FROM tex-deps AS builder
 
 WORKDIR /thesis
 
@@ -46,5 +64,15 @@ COPY text/ /thesis/
 RUN make pdf && \
     ls -lh /thesis/bakalarka.pdf
 
+# ============================================
+# Stage 3: Minimal runtime image with the PDF
+# ============================================
+FROM debian:bookworm-slim AS runtime
+
+WORKDIR /thesis
+
+# Copy only the compiled PDF from the builder stage.
+COPY --from=builder /thesis/bakalarka.pdf /thesis/bakalarka.pdf
+
 # Default command: copy PDF to mounted volume and signal completion
-CMD ["sh", "-c", "cp bakalarka.pdf /artifacts/ && echo 'Thesis compiled: bakalarka.pdf copied to /artifacts/'"]
+CMD ["sh", "-c", "cp /thesis/bakalarka.pdf /artifacts/ && echo 'Thesis compiled: bakalarka.pdf copied to /artifacts/'"]


### PR DESCRIPTION
**Problem**
`docker compose up --build` re-downloaded and re-installed the entire TeX Live / Czech language toolchain every time the `text` service was rebuilt.

**Root cause**
`text/Dockerfile` was never updated with the BuildKit cache-mount optimization applied to the other project Dockerfiles, so the `apt-get install` step had no persistent package cache.

**Changes**
- Add BuildKit syntax directive to `text/Dockerfile`.
- Introduce a `tex-deps` stage with a persistent apt cache mount and `Keep-Downloaded-Packages` so system packages are downloaded once and reused across builds.
- Split the PDF compilation into a `builder` stage so source edits do not invalidate the dependency layer.
- Add a minimal `runtime` stage that only ships `bakalarka.pdf`, shrinking the final image.
- Pass `BUILDKIT_INLINE_CACHE: 1` to the `text` service build in `docker-compose.yml` for consistency with `app` / `fast-sim`.

**Verification**
- `docker build -f text/Dockerfile . --check` passes with no warnings.
- First `tex-deps` build downloads and installs packages; a rebuild reports `CACHED` for the apt step.
- Full image builds successfully and the runtime container copies `bakalarka.pdf` to the mounted `/artifacts` volume.

Closes #524